### PR TITLE
Hotfix/#68 삭제된 영상에 대한 알림인 경우 알림 화면 전체를 확인할 수 없음

### DIFF
--- a/DanceMachine/DanceMachine/Common/Enum/Error/NotificationError.swift
+++ b/DanceMachine/DanceMachine/Common/Enum/Error/NotificationError.swift
@@ -13,6 +13,7 @@ enum NotificationError: LocalizedError {
   case badgeUpdateFailed(underlying: Error)
   case fetchUnreadCountFailed(underlying: Error)
   case markAsReadFailed(underlying: Error)
+  case delelteNotificationFalied(underlying: Error)
   
   var errorDescription: String? {
     switch self {
@@ -24,6 +25,8 @@ enum NotificationError: LocalizedError {
       return "서버에서 안 읽은 알림 개수를 가져오지 못했습니다. (\(underlying.localizedDescription))"
     case .markAsReadFailed(let underlying):
       return "알림 읽음 처리 과정에서 에러가 발생했습니다. (\(underlying.localizedDescription))"
+    case .delelteNotificationFalied(let underlying):
+      return "삭제된 영상이나 팀스페이스로 관련 정보(알림 문서, 사용자 알림 서브컬렉션) 삭제에 실패했습니다. (\(underlying.localizedDescription))"
     }
   }
 }

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/HomeView/HomeView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/HomeView/HomeView.swift
@@ -263,6 +263,7 @@ struct HomeView: View {
         try await viewModel.fetchUserInfo()
         await viewModel.ensureTeamspaceInitialized()
         await viewModel.fetchCurrentTeamspaceProject()
+        try await NotificationManager.shared.refreshBadge(for: FirebaseAuthManager.shared.user?.uid ?? "")
       } catch {
         
       }

--- a/DanceMachine/DanceMachine/Presentations/Inbox/ViewModels/InboxViewModel.swift
+++ b/DanceMachine/DanceMachine/Presentations/Inbox/ViewModels/InboxViewModel.swift
@@ -45,6 +45,7 @@ final class InboxViewModel: ObservableObject {
       canLoadMore = fetched.count == 20
       
       try await appendInboxNotifications(from: fetched, reset: reset)
+      try await NotificationManager.shared.refreshBadge(for: FirebaseAuthManager.shared.userInfo?.userId ?? "")
     } catch {
       print("❌ Failed to load notifications: \(error)")
     }
@@ -178,6 +179,12 @@ final class InboxViewModel: ObservableObject {
   }
   
   
+  private func getTeamspaceDoc(from id: String) async throws -> Teamspace {
+    let teamspaceDoc: Teamspace = try await FirestoreManager.shared.get(id, from: .teamspace)
+    return teamspaceDoc
+  }
+  
+  
   /// 특정 유저의 user_notification 서브컬렉션에서 is_read 상태를 가져옵니다.
   private func getNotificationReadState(userId: String, notificationId: String) async throws -> Bool {
     do {
@@ -224,6 +231,7 @@ struct InboxNotification: Equatable {
   let videoURL: String
   let videoTitle: String
   let senderName: String
+  let teamspace: Teamspace
   let content: String
   let date: Date
   let isRead: Bool

--- a/DanceMachine/DanceMachine/Presentations/Inbox/Views/InboxView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Inbox/Views/InboxView.swift
@@ -19,7 +19,7 @@ struct InboxView: View {
         if viewModel.isLoading && viewModel.inboxNotifications.isEmpty {
           LoadingSpinner()
             .frame(maxWidth: 28, maxHeight: 28, alignment: .center)
-        } else if !viewModel.inboxNotifications.isEmpty {
+        } else if viewModel.inboxNotifications.isEmpty {
           GeometryReader { geometry in
             ScrollView {
               VStack {

--- a/DanceMachine/DanceMachine/Presentations/Inbox/Views/InboxView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Inbox/Views/InboxView.swift
@@ -19,18 +19,26 @@ struct InboxView: View {
         if viewModel.isLoading && viewModel.inboxNotifications.isEmpty {
           LoadingSpinner()
             .frame(maxWidth: 28, maxHeight: 28, alignment: .center)
-        } else if viewModel.inboxNotifications.isEmpty {
-          VStack {
-            Spacer()
-            Image(systemName: "bell.slash.fill")
-              .resizable()
-              .foregroundStyle(.fillAssitive)
-              .frame(width: 138, height: 110)
-            Spacer().frame(height: 10)
-            Text("받은 알림이 없습니다.")
-              .font(.headline2Medium)
-              .foregroundStyle(.labelAssitive)
-            Spacer()
+        } else if !viewModel.inboxNotifications.isEmpty {
+          GeometryReader { geometry in
+            ScrollView {
+              VStack {
+                Spacer()
+                Image(systemName: "bell.slash.fill")
+                  .font(.system(size: 75))
+                  .foregroundStyle(.fillAssitive)
+                Spacer().frame(height: 10)
+                Text("받은 알림이 없습니다.")
+                  .font(.headline2Medium)
+                  .foregroundStyle(.labelAssitive)
+                Spacer()
+              }
+              .frame(maxWidth: .infinity, minHeight: geometry.size.height)
+            }
+            .presentationDragIndicator(.hidden)
+            .refreshable {
+              await viewModel.refresh()
+            }
           }
         } else {
           ScrollView {

--- a/DanceMachine/DanceMachine/Presentations/Inbox/Views/InboxView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Inbox/Views/InboxView.swift
@@ -72,7 +72,7 @@ struct InboxView: View {
             await viewModel.refresh()
           }
           
-          if viewModel.isLoading {
+          if !viewModel.isRefreshing && viewModel.isLoading {
             LoadingSpinner()
               .frame(maxWidth: 28, maxHeight: 28, alignment: .center)
               .padding(.top, 7)

--- a/DanceMachine/DanceMachine/Presentations/Login/Views/NameSettingView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Login/Views/NameSettingView.swift
@@ -82,7 +82,7 @@ struct NameSettingView: View {
         
         Spacer()
         
-        Text("이름이 정확하신가요?")
+        Text("이름이 정확한가요?")
           .font(.headline2Medium)
           .foregroundStyle(Color.labelNormal)
         

--- a/DanceMachine/DanceMachine/Presentations/RootView.swift
+++ b/DanceMachine/DanceMachine/Presentations/RootView.swift
@@ -11,7 +11,8 @@ struct RootView: View {
   
   @EnvironmentObject private var router: MainRouter
   @State var tabcase: TabCase = .home
-  
+  @StateObject private var notificationManager = NotificationManager.shared
+
   var body: some View {
     TabView(selection: $tabcase, content: {
       ForEach(TabCase.allCases, id: \.rawValue) { tab in
@@ -34,6 +35,7 @@ struct RootView: View {
           label: {
             tabLabel(tab)
           })
+        .badge(tab == .inbox ? notificationManager.unreadNotificationCount : 0)
       }
       //                  Tab(value: tabcase, role: .search) {
       //                    Color.clear
@@ -52,9 +54,6 @@ struct RootView: View {
         router.destination.removeAll()
       }
     }
-    
-    
-    
   }
   
   private func tabLabel(_ tab: TabCase) -> some View {

--- a/DanceMachine/DanceMachine/Service/FirestoreManager.swift
+++ b/DanceMachine/DanceMachine/Service/FirestoreManager.swift
@@ -368,10 +368,8 @@ final class FirestoreManager {
   /// 특정 유저의 알림 목록을 가져옵니다.
   /// - Parameters:
   ///   - userId: 유저의 document ID
-  ///   - currentTeamspaceId: 현재 팀스페이스 ID
   ///   - type: 콜렉션 타입 (현재 Notification)
   ///   - receiverIds: 푸시 알림 수신자 배열의 필드명
-  ///   - teamspaceField: 알림 문서의 팀스페이스 필드명
   ///   - orderKey: 정렬 기준 (현재, createdAt)
   ///   - descending: 내림 차순 정렬 여부 (현재는 true)
   ///   - limit: 가져오는 최대 목록 개수 (현재 최대 20개)
@@ -379,10 +377,8 @@ final class FirestoreManager {
   /// - Returns: 튜플 형태로 알림 목록과 해당 목록의 마지막 문서를 반환
   func fetchNotificationList<T: Decodable>(
     userId: String,
-    currentTeamspaceId: String,
     from type: CollectionType = .notification,
     where receiverIds: String = Notification.CodingKeys.receiverIds.rawValue,
-    teamspaceField: String = Notification.CodingKeys.teamspaceId.rawValue,
     orderBy orderKey: String = Notification.CodingKeys.createdAt.rawValue,
     descending: Bool = true,
     limit: Int = 20,
@@ -393,7 +389,6 @@ final class FirestoreManager {
     
     var q: Query = db.collection(type.rawValue)
       .whereField(receiverIds, arrayContains: userId)
-      .whereField(teamspaceField, isEqualTo: currentTeamspaceId)
       .whereField(orderKey, isGreaterThan: oneMonthAgoTimestamp)
       .order(by: orderKey, descending: descending)
       .limit(to: limit)


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 작업 이슈 번호를 입력해주세요
- Closes #68


## 🛠️ 작업내용
- 수신함에서 삭제된 영상에 대한 알림을 확인하면,  목록에서 확인 불가
- 알림 읽음 상태에 따라 앱아이콘 및 수신함 뱃지 카운트가 동기화
- 알림 가져오는 메서드에서 영상 정보를 불러오지 못하더라도 정상적으로 정보 받아온 알림은 확인할 수 있게 하기
- 삭제된 영상 혹은 팀스페이스에 대한 `notification` 문서 삭제
- 삭제된 영상 혹은 팀스페이스에 대한 `user_notification` 문서 삭제
- 앱아이콘 및 수신함 알림 뱃지 카운트 읽음 상태에 따라 갱신

## 📋 시연 영상
https://github.com/user-attachments/assets/a5b8a63d-9a06-42f1-9126-2041d8f93550



