### PR TITLE
Fix/#79 알림 목록이나 푸시 알림으로 현재 팀스페이스가 아닌 다른 팀스페이스 영상으로 이동하면 팀멤버 확인 불가

### DIFF
--- a/DanceMachine/DanceMachine/App/DanceMachineApp.swift
+++ b/DanceMachine/DanceMachine/App/DanceMachineApp.swift
@@ -141,13 +141,14 @@ extension DanceMachineApp {
           let query = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
           let videoId = query.first(where: { $0.name == "videoId" })?.value,
           let videoTitle = query.first(where: { $0.name == "videoTitle" })?.value,
-          let videoURL = query.first(where: { $0.name == "videoURL" })?.value else {
+          let videoURL = query.first(where: { $0.name == "videoURL" })?.value,
+          let teamspaceId = query.first(where: { $0.name == "teamspaceId" })?.value else {
       print("❌ Invalid video deeplink:", url.absoluteString)
       return
     }
     
     // videoView (영상 화면)으로 이동
-    mainRouter.push(to: .video(.play(videoId: videoId, videoTitle: videoTitle, videoURL: videoURL)))
+    mainRouter.push(to: .video(.play(videoId: videoId, videoTitle: videoTitle, videoURL: videoURL, teamspaceId: teamspaceId)))
     
     print("🎬 Navigate to VideoView:", videoTitle)
   }

--- a/DanceMachine/DanceMachine/Navigation/MainNavigationRoutingView.swift
+++ b/DanceMachine/DanceMachine/Navigation/MainNavigationRoutingView.swift
@@ -65,11 +65,12 @@ struct MainNavigationRoutingView: View {
             trackName: trackName,
             sectionId: sectionId
           )
-        case .play(let videoId, let videoTitle, let videoURL):
+        case .play(let videoId, let videoTitle, let videoURL, let teamspaceId):
           VideoView(
             videoId: videoId,
             videoTitle: videoTitle,
-            videoURL: videoURL
+            videoURL: videoURL,
+            teamspaceId: teamspaceId
           )
         }
       }

--- a/DanceMachine/DanceMachine/Navigation/NavigationDestination.swift
+++ b/DanceMachine/DanceMachine/Navigation/NavigationDestination.swift
@@ -67,7 +67,7 @@ enum MyPageRoute: Hashable {
 enum VideoRoute: Hashable {
   case list(tracksId: String, sectionId: String, trackName: String)
   case section(section: [Section], tracksId: String, trackName: String, sectionId: String)
-  case play(videoId: String, videoTitle: String, videoURL: String)
+  case play(videoId: String, videoTitle: String, videoURL: String, teamspaceId: String)
 }
 
 enum FloatingButtonType {

--- a/DanceMachine/DanceMachine/Presentations/Home/ViewModels/VideoPlay/VideoDetailViewModel.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/ViewModels/VideoPlay/VideoDetailViewModel.swift
@@ -53,7 +53,7 @@ final class VideoDetailViewModel {
           try await self.videoVM.setupPlayer(from: videoURL, videoId: videoId)
         }
         g.addTask {
-          try await self.loadTeamMemvers(teamspaceId: teamspaceId)
+          try await self.loadTeamMembers(teamspaceId: teamspaceId)
         }
         g.addTask {
           try await self.feedbackVM.loadFeedbacks(for: videoId)
@@ -75,7 +75,7 @@ final class VideoDetailViewModel {
 // MARK: 팀 스페이스 관련
 extension VideoDetailViewModel {
   // 팀 스페이스 멤버 조회
-  func loadTeamMemvers(teamspaceId: String) async throws {
+  func loadTeamMembers(teamspaceId: String) async throws {
     do {
       let members: [Members] = try await store.fetchAllFromSubcollection(
         under: .teamspace,

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/Component/VideoGrid/VideoGrid.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/Component/VideoGrid/VideoGrid.swift
@@ -59,6 +59,7 @@ struct VideoGrid: View {
         ForEach(videos, id: \.videoId) { video in
           if let track = track.first(where: { $0.videoId == video.videoId.uuidString }) {
             let currentUserId = FirebaseAuthManager.shared.userInfo?.userId ?? ""
+            let currentTeamspaceId: String = FirebaseAuthManager.shared.currentTeamspace?.teamspaceId.uuidString ?? ""
             
             GridCell(
               size: size,
@@ -86,6 +87,7 @@ struct VideoGrid: View {
                       videoId: video.videoId.uuidString,
                       videoTitle: video.videoTitle,
                       videoURL: video.videoURL,
+                      teamspaceId: currentTeamspaceId
                     )
                   )
                 )

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/VideoView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/VideoView.swift
@@ -65,13 +65,13 @@ struct VideoView: View {
   @State private var showFeedbackImageFull: Bool = false
   
   // MARK: 전역으로 관리되는 ID
-  let teamspaceId = FirebaseAuthManager.shared.currentTeamspace?.teamspaceId
-  let userId = FirebaseAuthManager.shared.userInfo?.userId ?? ""
-  
+  let userId: String = FirebaseAuthManager.shared.userInfo?.userId ?? ""
   
   let videoId: String
   let videoTitle: String
   let videoURL: String
+  let teamspaceId: String
+
   
   // 피드백 필터링 (내 피드백, 전체 피드백)
   var filteredFeedbacks: [Feedback] {
@@ -269,7 +269,7 @@ struct VideoView: View {
       await self.vm.loadAllData(
         videoId: videoId,
         videoURL: videoURL,
-        teamspaceId: teamspaceId?.uuidString ?? ""
+        teamspaceId: teamspaceId
       )
     }
     .onDisappear {
@@ -820,7 +820,8 @@ struct VideoView: View {
     VideoView(
       videoId: "3",
       videoTitle: "벨코의 리치맨",
-      videoURL: "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+      videoURL: "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+      teamspaceId: ""
     )
   }
   .environmentObject(MainRouter())

--- a/DanceMachine/DanceMachine/Presentations/Inbox/Views/InboxView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Inbox/Views/InboxView.swift
@@ -61,7 +61,8 @@ struct InboxView: View {
                           .play(
                             videoId: notification.videoId,
                             videoTitle: notification.videoTitle,
-                            videoURL: notification.videoURL
+                            videoURL: notification.videoURL,
+                            teamspaceId: notification.teamspace.teamspaceId.uuidString
                           )
                         )
                       )


### PR DESCRIPTION
## 🐛 Fix

어떤 변경 사항이 있나요??
- [x] 버그 수정


## 작업 이슈 번호를 입력해주세요
- Closes #79 


## 🛠️ 작업내용
- 영상 화면으로 내비게이션 할 때, 개별적으로 팀스페이스 ID 를 넘겨주기 (영상 목록에서 이동 / 푸시 알림으로 이동 / 알림 목록에서 이동)
- 푸시 알림으로 영상 화면으로 이동하고 팀스페이스 정보를 받아서 팀멤버를 갱신할 수 있도록 팀스페이스 ID를 푸시 알림 정보에 담아서 푸시 알림 보내기

## ✅ 체크리스트
- 현재 팀스페이스와 다른 팀스페이스의 영상 화면으로 이동해도 팀멤버가 잘 보여야 합니다.

## 📋 시연 영상
https://github.com/user-attachments/assets/690f9dd7-5818-42ed-a62b-6b6e70f95195






