### PR TITLE
Fix/#119 - 아이폰 SE에서 아래 회원탈퇴 레이블 패딩 수정

### DIFF
--- a/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountSettingView.swift
+++ b/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountSettingView.swift
@@ -42,6 +42,8 @@ struct AccountSettingView: View {
           Text("회원탈퇴")
             .foregroundStyle(.accentRedStrong)
         }
+        .padding(.top, 8)
+        .padding(.bottom, 16)
       }
     }
     .toolbar {


### PR DESCRIPTION
## 🐛 Fix

어떤 변경 사항이 있나요??
- [X] 버그 수정
- [X] 사용자 UI 디자인 변경 및 추가


## 작업 이슈 번호를 입력해주세요
- Closes #119 


## 🛠️ 작업내용
- 아이폰SE 에서 확인되는 계정 설정 화면의 하단 버튼 공백 추가

## 📋 스크린샷

### 아이폰SE
<img width="590" height="1278" alt="iPhone SE" src="https://github.com/user-attachments/assets/f3012deb-1443-4e19-882b-d8e64fd302d7" />

### 아이폰16
<img width="590" height="1278" alt="iPhone 16" src="https://github.com/user-attachments/assets/ffa87e21-361f-4251-a3bf-8c92c76a2408" />






