### PR TITLE
Fix/#131 - ToolbarCenterTitle 중앙 정렬 안됨

### DIFF
--- a/DanceMachine/DanceMachine/Common/Components/Toolbar/ToolbarCenterTitle.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Toolbar/ToolbarCenterTitle.swift
@@ -17,7 +17,6 @@ struct ToolbarCenterTitle: ToolbarContent {
         .font(.heading1Medium)
         .foregroundStyle(.labelStrong)
         .allowsHitTesting(false)
-        .frame(maxWidth: .infinity)
     }
   }
 }

--- a/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountSettingView.swift
+++ b/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountSettingView.swift
@@ -42,6 +42,8 @@ struct AccountSettingView: View {
           Text("회원탈퇴")
             .foregroundStyle(.accentRedStrong)
         }
+        .padding(.top, 8)
+        .padding(.bottom, 16)
       }
     }
     .toolbar {


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??
- [x] 버그 수정


## 작업 이슈 번호를 입력해주세요
- Closes #131 

## 🛠️ 작업내용
- `ToolbarCenterTitle`에서 `.frame(maxWidth: infinity)` 코드 삭제

## 📋 스크린샷

### iPhone SE (iOS 18)

<img width="320" height="980" alt="iPhone SE(1)" src="https://github.com/user-attachments/assets/1326b28e-b28d-4f86-b03e-dcc5981d29e3" />
<img width="320" height="980" alt="iPhone SE(2)" src="https://github.com/user-attachments/assets/d8adf8f6-99d7-4201-9e1f-a28469390f72" />


### iPhone 16 (iOS 26)

<img width="320" height="980" alt="iPhone 16(1)" src="https://github.com/user-attachments/assets/993318a6-8616-4996-9d64-b0c2ae18aea1" />
<img width="320" height="980" alt="iPhone 16(2)" src="https://github.com/user-attachments/assets/4e392b89-fc86-43cb-94f7-abd6fc98cc42" />


### iPad 11 Pro (iPadOS 26)

<img width="1210" height="834" alt="Center_Title_iPadOS 26(1)" src="https://github.com/user-attachments/assets/2a79e18c-1c4e-4805-9344-e7677fd68657" />
<img width="1210" height="834" alt="Center_Title_iPadOS 26(2)" src="https://github.com/user-attachments/assets/b6d9759c-1249-42c1-8e49-57a501910184" />




