### PR TITLE
Fix/ipad - iOS18 아이패드 터치이슈 해결 + 각종 버그 수정

### DIFF
--- a/DanceMachine/DanceMachine/Common/Components/Feedback/CustomTextField.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Feedback/CustomTextField.swift
@@ -38,12 +38,17 @@ struct CustomTextField: View {
         )
       
       Button {
-        submitAction()
-        isFocused = false
       } label: {
         Image(systemName: "paperplane.fill")
           .font(.system(size: 19))
           .foregroundStyle(content.isEmpty ? .fillAssitive : .secondaryStrong)
+          .simultaneousGesture(
+            TapGesture()
+              .onEnded {
+                submitAction()
+                isFocused = false
+              }
+          )
       }
       .disabled(content.trimmingCharacters(in: .whitespaces).isEmpty)
       .frame(width: 18, height: 18)

--- a/DanceMachine/DanceMachine/Common/Components/Feedback/CustomTextField.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Feedback/CustomTextField.swift
@@ -20,11 +20,11 @@ struct CustomTextField: View {
   var body: some View {
     ZStack(alignment: .trailing) {
       TextField(placeHolder, text: $content, axis: .vertical)
+        .autocorrectionDisabled(true)
+        .textInputAutocapitalization(.never)
         .focused($isFocused)
         .font(.headline2Medium)
         .foregroundStyle(Color.labelStrong)
-        .textInputAutocapitalization(.sentences)
-        .autocorrectionDisabled(false)
         .padding(.leading, 16)
         .padding(.vertical, 12)
         .padding(.trailing, 40)

--- a/DanceMachine/DanceMachine/Common/Components/Feedback/FeedbackButton.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Feedback/FeedbackButton.swift
@@ -61,6 +61,12 @@ struct FeedbackButtons: View {
           .font(.system(size: 20))
           .foregroundStyle(.labelStrong)
       }
+      .simultaneousGesture(
+        TapGesture()
+          .onEnded {
+            pointAction()
+          }
+      )
       .padding(.horizontal, 4)
       .padding(.vertical, 14)
       .frame(maxWidth: .infinity)
@@ -87,6 +93,12 @@ struct FeedbackButtons: View {
             .foregroundStyle(.primitiveButton)
         }
       }
+      .simultaneousGesture(
+        TapGesture()
+          .onEnded {
+            intervalAction()
+          }
+      )
       .padding(.horizontal, 4)
       .padding(.vertical, 14)
       .frame(maxWidth: .infinity)

--- a/DanceMachine/DanceMachine/Common/Components/Feedback/FeedbackCard.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Feedback/FeedbackCard.swift
@@ -70,9 +70,15 @@ struct FeedbackCard: View {
       }
     }
     .contentShape(Rectangle())
-    .onTapGesture {
-      action()
-    }
+    .gesture(
+      TapGesture()
+        .onEnded {
+          action()
+        }
+    )
+//    .onTapGesture {
+//      action()
+//    }
     .onLongPressGesture(perform: {
       action()
     })
@@ -186,6 +192,12 @@ struct FeedbackCard: View {
           .font(.system(size: 12))
           .foregroundStyle(.primitiveAssitive)
       }
+      .simultaneousGesture(
+        TapGesture()
+          .onEnded {
+            showReplySheet()
+          }
+      )
     }
     .buttonStyle(.plain)
     .frame(maxWidth: .infinity, alignment: .trailing)
@@ -232,9 +244,15 @@ struct FeedbackCard: View {
             .frame(width: 100, height: 100)
             .clipShape(RoundedRectangle(cornerRadius: 8))
             .matchedGeometryEffect(id: urlString, in: ns)   // 🔥 hero 연결
-            .onTapGesture {
-              onImageTap?(urlString)
-            }
+            .simultaneousGesture(
+              TapGesture()
+                .onEnded {
+                  onImageTap?(urlString)
+                }
+            )
+//            .onTapGesture {
+//              onImageTap?(urlString)
+//            }
         } else {
           // 기존 동작(히어로 없이)도 유지
           KFImage(url)
@@ -252,9 +270,15 @@ struct FeedbackCard: View {
             .scaledToFill()
             .frame(width: 100, height: 100)
             .clipShape(RoundedRectangle(cornerRadius: 8))
-            .onTapGesture {
-              onImageTap?(urlString)
-            }
+            .simultaneousGesture(
+              TapGesture()
+                .onEnded {
+                  onImageTap?(urlString)
+                }
+            )
+//            .onTapGesture {
+//              onImageTap?(urlString)
+//            }
         }
       }
     }

--- a/DanceMachine/DanceMachine/Common/Components/Feedback/MentionPicker.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Feedback/MentionPicker.swift
@@ -75,6 +75,12 @@ struct MentionPicker: View { // FIXME: 디자인 필요
         )
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .contentShape(Rectangle())
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              selectAll()
+            }
+        )
     }
     .buttonStyle(.plain)
   }
@@ -97,6 +103,12 @@ struct MentionPicker: View { // FIXME: 디자인 필요
           )
           .clipShape(RoundedRectangle(cornerRadius: 10))
           .contentShape(Rectangle())
+          .simultaneousGesture(
+            TapGesture()
+              .onEnded {
+                action(user)
+              }
+          )
       }
       .buttonStyle(.plain)
     }

--- a/DanceMachine/DanceMachine/Common/Components/Feedback/TimestampButton.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Feedback/TimestampButton.swift
@@ -10,19 +10,19 @@ import SwiftUI
 struct TimestampButton: View {
   let text: String
   let timeSeek: () -> Void
-  
+
   var body: some View {
-    Button {
+    HStack(spacing: 4) {
+      Image(systemName: "clock")
+        .font(.system(size: 18))
+        .foregroundStyle(.secondaryNormal)
+      Text(text)
+        .font(.headline2Medium)
+        .foregroundStyle(.secondaryNormal)
+    }
+    .contentShape(Rectangle())
+    .onTapGesture {
       timeSeek()
-    } label: {
-      HStack(spacing: 4) {
-        Image(systemName: "clock")
-          .font(.system(size: 18))
-          .foregroundStyle(.secondaryNormal)
-        Text(text)
-          .font(.headline2Medium)
-          .foregroundStyle(.secondaryNormal)
-      }
     }
   }
 }
@@ -30,26 +30,26 @@ struct TimestampButton: View {
 struct TimestampInput: View {
   let text: String
   let timeSeek: () -> Void
-  
+
   var body: some View {
-    Button {
-      timeSeek()
-    } label: {
-      HStack(spacing: 4) {
-        Image(systemName: "clock")
-          .font(.footnoteMedium)
-          .foregroundStyle(.labelStrong)
-        Text(text)
-          .font(.footnoteMedium)
-          .foregroundStyle(.labelStrong)
-      }
-      .padding(.vertical, 6)
-      .padding(.horizontal, 8)
+    HStack(spacing: 4) {
+      Image(systemName: "clock")
+        .font(.footnoteMedium)
+        .foregroundStyle(.labelStrong)
+      Text(text)
+        .font(.footnoteMedium)
+        .foregroundStyle(.labelStrong)
     }
+    .padding(.vertical, 6)
+    .padding(.horizontal, 8)
     .background {
       RoundedRectangle(cornerRadius: 1000)
         .fill(Color.secondaryStrong)
         .stroke(Color.labelStrong, lineWidth: 1)
+    }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      timeSeek()
     }
   }
 }

--- a/DanceMachine/DanceMachine/Common/Components/Home/TrackAddButtonRow.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Home/TrackAddButtonRow.swift
@@ -19,7 +19,7 @@ struct TrackAddButtonRow: View {
           .resizable()
           .scaledToFit()
           .frame(width: 17, height: 17)
-        
+
         Text("곡 추가하기")
           .font(.headline2Medium)
           .foregroundStyle(Color.labelStrong)
@@ -29,6 +29,12 @@ struct TrackAddButtonRow: View {
       .background(
         RoundedRectangle(cornerRadius: 15)
           .fill(isEmptyTracks ? Color.secondaryStrong : Color.fillAssitive)
+      )
+      .simultaneousGesture(
+        TapGesture()
+          .onEnded {
+            action()
+          }
       )
     }
     .buttonStyle(.plain)

--- a/DanceMachine/DanceMachine/Common/Components/Reply/ReplyCard.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Reply/ReplyCard.swift
@@ -108,6 +108,12 @@ struct ReplyCard: View {
       Text("답글달기")
         .font(.caption1Medium)
         .foregroundStyle(.labelNormal)
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              replyAction()
+            }
+        )
     }
     .buttonStyle(.plain)
   }

--- a/DanceMachine/DanceMachine/Common/Components/Reply/TaggedUsersView.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Reply/TaggedUsersView.swift
@@ -36,6 +36,12 @@ struct TaggedUsersView: View {
                 .symbolRenderingMode(.hierarchical)
                 .font(.system(size: 16))
                 .foregroundStyle(Color.labelAssitive)
+                .simultaneousGesture(
+                  TapGesture()
+                    .onEnded {
+                      onRemoveAll()
+                    }
+                )
             }
           }
           .animation(nil, value: taggedUsers)
@@ -56,6 +62,12 @@ struct TaggedUsersView: View {
                   .symbolRenderingMode(.hierarchical)
                   .font(.system(size: 16))
                   .foregroundStyle(Color.labelAssitive)
+                  .simultaneousGesture(
+                    TapGesture()
+                      .onEnded {
+                        onRemove(user.userId)
+                      }
+                  )
               }
             }
             .animation(nil, value: taggedUsers)

--- a/DanceMachine/DanceMachine/Common/Components/Toolbar/ToolbarLeadingBackButton.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Toolbar/ToolbarLeadingBackButton.swift
@@ -27,6 +27,16 @@ struct ToolbarLeadingBackButton: ToolbarContent {
         Image(systemName: icon.toolIcon)
           .foregroundStyle(.labelStrong)
           .frame(width: 22, height: 22)
+          .simultaneousGesture(
+            TapGesture()
+              .onEnded {
+                if let action = action {
+                  action()
+                } else {
+                  dismiss()
+                }
+              }
+          )
       }
     }
   }

--- a/DanceMachine/DanceMachine/Common/Components/Toolbar/ToolbarUploadButton.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Toolbar/ToolbarUploadButton.swift
@@ -12,14 +12,39 @@ struct ToolbarUploadButton: ToolbarContent {
 
   var body: some ToolbarContent {
     ToolbarItem(placement: .topBarTrailing) {
-      Button {
-        action()
-      } label: {
-        Image(.videoUpload)
+      if #available(iOS 26.0, *) {
+        Button {
+          action()
+        } label: {
+          Image(.videoUpload)
+            .simultaneousGesture(
+              TapGesture()
+                .onEnded {
+                  action()
+                }
+            )
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(.secondaryAlternativeGlass)
+        .environment(\.colorScheme, .light)
+      } else {
+        Button {
+          action()
+        } label: {
+          ZStack {
+            Circle().fill(Color.secondaryNormal)
+              .frame(width: 44, height: 44)
+            Image(.videoUpload)
+          }
+          .simultaneousGesture(
+            TapGesture()
+              .onEnded {
+                action()
+              }
+          )
+        }
+        .environment(\.colorScheme, .light)
       }
-      .buttonStyle(.borderedProminent)
-      .tint(.secondaryAlternativeGlass)
-      .environment(\.colorScheme, .light)
     }
   }
 }

--- a/DanceMachine/DanceMachine/Common/Components/Video/VideoOverlay/CustomSlider.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Video/VideoOverlay/CustomSlider.swift
@@ -49,7 +49,7 @@ struct CustomSlider: View {
               x: progressWidth(g.size.width) -
               (isDragging ? 10 : 5)
             )
-            .gesture(
+            .simultaneousGesture(
               DragGesture()
                 .onChanged({ value in
                   isDragging = true
@@ -69,11 +69,14 @@ struct CustomSlider: View {
             )
         }
         .contentShape(Rectangle())
-        .onTapGesture { location in
-          let p = location.x / g.size.width
-          let new = p * duration
-          onSeek(new)
-        }
+        .simultaneousGesture(
+          DragGesture(minimumDistance: 0)
+            .onEnded { value in
+              let p = value.location.x / g.size.width
+              let new = p * duration
+              onSeek(new)
+            }
+        )
         .animation(.easeIn(duration: 0.1), value: isDragging)
       }
       .frame(height: 25)

--- a/DanceMachine/DanceMachine/Common/Components/Video/VideoOverlay/OverlayController.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Video/VideoOverlay/OverlayController.swift
@@ -33,6 +33,12 @@ struct OverlayController: View {
       Image(systemName: "gobackward.5")
         .font(.system(size: 30))
         .foregroundStyle(.labelStrong)
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              leftAction()
+            }
+        )
     }
     .frame(width: 55, height: 55)
     .overlayController()
@@ -47,6 +53,12 @@ struct OverlayController: View {
       )
       .font(.system(size: 44))
       .foregroundStyle(.labelStrong)
+      .simultaneousGesture(
+        TapGesture()
+          .onEnded {
+            centerAction()
+          }
+      )
     }
     .frame(width: 70, height: 70)
     .overlayController()
@@ -59,6 +71,12 @@ struct OverlayController: View {
       Image(systemName: "goforward.5")
         .font(.system(size: 30))
         .foregroundStyle(.labelStrong)
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              rightAction()
+            }
+        )
     }
     .frame(width: 55, height: 55)
     .overlayController()

--- a/DanceMachine/DanceMachine/Common/Components/Video/VideoOverlay/VideoSettingButtons.swift
+++ b/DanceMachine/DanceMachine/Common/Components/Video/VideoOverlay/VideoSettingButtons.swift
@@ -45,11 +45,16 @@ struct VideoSettingButtons: View {
   
   private var drawingButton: some View {
     Button {
-      drawingAction()
     } label: {
       Image(systemName: "scribble.variable")
         .font(.system(size: 20))
         .foregroundStyle(.labelStrong)
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              drawingAction()
+            }
+        )
     }
     .frame(width: 44, height: 44)
     .contentShape(Rectangle())
@@ -58,13 +63,18 @@ struct VideoSettingButtons: View {
 
   private var feedbackToggleButton: some View {
     Button {
-      toggleFeedbackPanel?()
     } label: {
       Image(
         systemName: showFeedbackPanel ? "chevron.right" : "chevron.left"
       )
         .font(.system(size: 20))
         .foregroundStyle(.labelStrong)
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              toggleFeedbackPanel?()
+            }
+        )
     }
     .frame(width: 44, height: 44)
     .contentShape(Rectangle())
@@ -73,11 +83,16 @@ struct VideoSettingButtons: View {
 
   private var timeButton: some View {
     Button {
-      action()
     } label: {
       Image(.speedometer)
         .font(.system(size: 20))
         .foregroundStyle(.labelStrong)
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              action()
+            }
+        )
     }
     .frame(width: 44, height: 44)
     .contentShape(Rectangle())
@@ -87,11 +102,16 @@ struct VideoSettingButtons: View {
   // 아래쪽 버튼: 항상 전체화면 토글
   private var orientationButton: some View {
     Button {
-      toggleOrientations()
     } label: {
       Image(systemName: isLandscapeMode ? "arrow.up.right.and.arrow.down.left.rectangle" : "arrow.down.left.and.arrow.up.right.rectangle")
         .font(.system(size: 20))
         .foregroundStyle(.labelStrong)
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              toggleOrientations()
+            }
+        )
     }
     .frame(width: 44, height: 44)
     .contentShape(Rectangle())

--- a/DanceMachine/DanceMachine/Common/Components/VideoList/Section/SectionChip.swift
+++ b/DanceMachine/DanceMachine/Common/Components/VideoList/Section/SectionChip.swift
@@ -20,6 +20,12 @@ struct SectionChipIcon: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 5)
         .sectionIcon()
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              action()
+            }
+        )
     }
   }
 }
@@ -39,6 +45,12 @@ struct CustomSectionChip: View {
         .foregroundStyle(.labelStrong)
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              action()
+            }
+        )
         .sectionChip(isSelected: vm.selectedSection?.sectionId == id)
     }
   }

--- a/DanceMachine/DanceMachine/Common/Components/VideoList/Section/SectionEditRow.swift
+++ b/DanceMachine/DanceMachine/Common/Components/VideoList/Section/SectionEditRow.swift
@@ -33,6 +33,8 @@ struct SectionEditRow: View {
     HStack {
       if isEditing {
         TextField("파트 이름", text: $editText)
+          .autocorrectionDisabled(true)
+          .textInputAutocapitalization(.never)
           .textFieldStyle(.plain)
           .font(.headline2Medium)
           .foregroundStyle(.labelStrong)

--- a/DanceMachine/DanceMachine/Common/Components/VideoList/Skeleton/UploadProgressCard.swift
+++ b/DanceMachine/DanceMachine/Common/Components/VideoList/Skeleton/UploadProgressCard.swift
@@ -82,17 +82,21 @@ struct UploadProgressCard: View {
   }
   
   private var topSkeletonView: some View {
-    SkeletonView(
-      RoundedCorner(radius: 10, corners: [.topLeft, .topRight]),
-      Color.fillNormal
-    )
+//    SkeletonView(
+//      RoundedCorner(radius: 10, corners: [.topLeft, .topRight]),
+//      Color.fillNormal
+//    )
+    RoundedCorner(radius: 10, corners: [.topLeft, .topRight])
+      .fill(Color.fillNormal)
   }
   
   private var bottomSkeletonView: some View {
-    SkeletonView(
-      RoundedRectangle(cornerRadius: 5),
-      Color.fillNormal
-    )
+//    SkeletonView(
+//      RoundedRectangle(cornerRadius: 5),
+//      Color.fillNormal
+//    )
+    RoundedRectangle(cornerRadius: 5)
+      .fill(Color.fillNormal)
   }
   
   // MARK: fileTooLarge
@@ -108,6 +112,14 @@ struct UploadProgressCard: View {
           Image(systemName: "xmark")
             .font(.system(size: 30, weight: .semibold))
             .foregroundStyle(Color.secondaryNormal)
+            .simultaneousGesture(
+              TapGesture()
+                .onEnded {
+                  Task {
+                    await onCancel()
+                  }
+                }
+            )
         }
       }
     }
@@ -222,6 +234,14 @@ struct UploadProgressCard: View {
             .font(.system(size: cardSize * 0.2, weight: .bold))
             .foregroundStyle(Color.secondaryNormal)
         }
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              Task {
+                await onRetry()
+              }
+            }
+        )
       }
     }
     .padding(.horizontal, cardSize * 0.1)
@@ -251,6 +271,14 @@ struct UploadProgressCard: View {
         Text("취소")
           .font(.caption1Medium)
           .foregroundStyle(.accentRedNormal)
+          .simultaneousGesture(
+            TapGesture()
+              .onEnded {
+                Task {
+                  await onCancel()
+                }
+              }
+          )
       }
       Spacer().frame(height: 16)
     }

--- a/DanceMachine/DanceMachine/Common/Components/VideoList/VideoGrid/GridCell.swift
+++ b/DanceMachine/DanceMachine/Common/Components/VideoList/VideoGrid/GridCell.swift
@@ -41,6 +41,12 @@ struct GridCell: View {
     )
     .sensoryFeedback(.success, trigger: showMenu)
     .onTapGesture { videoAction() }
+    .simultaneousGesture(
+      TapGesture()
+        .onEnded {
+          videoAction()
+        }
+    )
     .overlay(alignment: .topTrailing) {
       Menu {
         contextRows
@@ -49,6 +55,12 @@ struct GridCell: View {
           .foregroundStyle(.labelStrong)
           .rotationEffect(.degrees(90))
           .frame(width: 33, height: 33)
+          .simultaneousGesture(
+            TapGesture()
+              .onEnded {
+                showMenu.toggle()
+              }
+          )
       }
     }
     .contextMenu {

--- a/DanceMachine/DanceMachine/Common/Components/VideoList/VideoGrid/VideoGrid.swift
+++ b/DanceMachine/DanceMachine/Common/Components/VideoList/VideoGrid/VideoGrid.swift
@@ -14,6 +14,7 @@ struct VideoGrid: View {
   let columns: Int
   let spacing: CGFloat
   let tracksId: String
+  let sectionId: String
 
   let videos: [Video]
   let track: [Track]
@@ -36,22 +37,25 @@ struct VideoGrid: View {
       ),
       spacing: spacing
     ) {
-      switch progressManager.uploadState {
-      case .compressing, .uploading, .failed, .fileToLarge:
-        UploadProgressCard(
-          cardSize: size,
-          progressManager: progressManager,
-          onRetry: { await pickerViewModel.retryUpload() },
-          onCancel: { await pickerViewModel.cancelUpload() }
-        )
-      case .idle:
-        EmptyView()
-      }
       if vm.isLoading {
         ForEach(0..<6, id: \.self) { _ in
           SkeletonCardView(cardSize: size)
         }
       } else {
+        if progressManager.currentTracksId == tracksId &&
+           progressManager.currentSectionId == sectionId {
+          switch progressManager.uploadState {
+          case .compressing, .uploading, .failed, .fileToLarge:
+            UploadProgressCard(
+              cardSize: size,
+              progressManager: progressManager,
+              onRetry: { await pickerViewModel.retryUpload() },
+              onCancel: { await pickerViewModel.cancelUpload() }
+            )
+          case .idle:
+            EmptyView()
+          }
+        }
         ForEach(videos, id: \.videoId) { video in
           if let track = track.first(where: { $0.videoId == video.videoId.uuidString }) {
             let currentUserId = FirebaseAuthManager.shared.userInfo?.userId ?? ""
@@ -169,6 +173,7 @@ extension Video: Identifiable {
     columns: 2,
     spacing: 16,
     tracksId: "",
+    sectionId: "",
     videos: [Video(
       videoId: UUID(),
       videoTitle: "벨코의 리치맨",

--- a/DanceMachine/DanceMachine/Presentations/Home/ViewModels/VideoUpload/VideoPickerViewModel.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/ViewModels/VideoUpload/VideoPickerViewModel.swift
@@ -164,7 +164,7 @@ extension VideoPickerViewModel {
             let duration = try await self.getDuration(from: urlAsset)
 
             await MainActor.run {
-              self.progressManager.startCompressing()
+              self.progressManager.startCompressing(tracksId: tracksId, sectionId: sectionId)
             }
             // 압축
             let compressionURL = try await self.compressionManager.compressIfNeeded(
@@ -176,7 +176,7 @@ extension VideoPickerViewModel {
               }
 
             await MainActor.run {
-              self.progressManager.startUpload()
+              self.progressManager.startUpload(tracksId: tracksId, sectionId: sectionId)
             }
 
             let (video, track) = try await self.generateVideo(
@@ -457,7 +457,7 @@ extension VideoPickerViewModel {
 
     await MainActor.run {
       self.isLoading = true
-      self.progressManager.startCompressing()
+      self.progressManager.startCompressing(tracksId: context.tracksId, sectionId: context.sectionId)
     }
 
     // 기존 데이터 정리
@@ -481,7 +481,7 @@ extension VideoPickerViewModel {
         }
       
       await MainActor.run {
-        self.progressManager.startUpload()
+        self.progressManager.startUpload(tracksId: context.tracksId, sectionId: context.sectionId)
       }
 
       let (video, track) = try await generateVideo(

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/HomeView/HomeViews/TeamspaceTitleView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/HomeView/HomeViews/TeamspaceTitleView.swift
@@ -54,13 +54,19 @@ struct TeamspaceTitleView: View {
           Text(Layout.EmptyTeamspaceViewLayout.titleText)
             .font(.heading1SemiBold)
             .foregroundStyle(Color.labelStrong)
-          
+
           Image(systemName: Layout.EmptyTeamspaceViewLayout.imageName)
             .font(.system(size: Layout.EmptyTeamspaceViewLayout.imageFontSize, weight: .medium))
             .foregroundStyle(Color.labelStrong)
         }
         .padding(.vertical, 6.5)
       }
+      .simultaneousGesture(
+        TapGesture()
+          .onEnded {
+            self.router.push(to: .teamspace(.create))
+          }
+      )
     }
   }
   
@@ -83,6 +89,12 @@ struct TeamspaceTitleView: View {
             Image(systemName: Layout.NonEmptyTeamspaceViewLayout.imageName)
               .font(.system(size: Layout.NonEmptyTeamspaceViewLayout.imageFontSize, weight: .medium))
               .foregroundStyle(Color.labelStrong)
+              .simultaneousGesture(
+                TapGesture()
+                  .onEnded {
+                    router.push(to: .teamspace(.setting))
+                  }
+              )
           }
           .clearGlassButtonIfAvailable()
         }

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/HomeView/ProjectViews/ProjectListHeaderView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/HomeView/ProjectViews/ProjectListHeaderView.swift
@@ -35,6 +35,14 @@ struct ProjectListHeaderView: View {
               }
               .foregroundStyle(Color.secondaryNormal)
               .transition(.move(edge: .bottom).combined(with: .opacity))
+              .simultaneousGesture(
+                TapGesture()
+                  .onEnded {
+                    if !isEditing {
+                      viewModel.presentationState.presentingCreateProjectSheet = true
+                    }
+                  }
+              )
             } else {
               CheckmarkButton(disable: isPrimaryDisabled) {
                 onPrimaryUpdate()

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/HomeView/ProjectViews/ProjectListView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/HomeView/ProjectViews/ProjectListView.swift
@@ -147,6 +147,12 @@ struct ProjectListView: View {
           .font(.system(size: Layout.EmptyProjectView.imageSize))
           .foregroundStyle(Color.secondaryNormal)
           .frame(maxWidth: .infinity)
+          .simultaneousGesture(
+            TapGesture()
+              .onEnded {
+                projectListViewModel.presentationState.presentingCreateProjectSheet = true
+              }
+          )
       }
       Text(Layout.EmptyProjectView.titleText)
         .font(.headline2Medium)

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/SectionEditView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/SectionEditView.swift
@@ -14,8 +14,9 @@ struct SectionEditView: View {
   @State private var showExitAlert: Bool = false
   @State private var showDeleteAlert: Bool = false
   @State private var sectionToDelete: Section? = nil
-  
+
   @State private var showCRUDToast: Bool = false
+  @State private var checkEffectActive: Bool = false
   
   let tracksId: String
   let trackName: String
@@ -133,15 +134,21 @@ struct SectionEditView: View {
   private var emptyView: some View {
     GeometryReader { geometry in
       VStack {
-        Button {
-          vm.addNewSection()
-        } label: {
-          VStack(spacing: 24) {
-            Image(.sectionAdd)
-            Text("파트를 추가해 보세요.")
-              .font(.headline2Medium)
-              .foregroundStyle(.secondaryAssitive)
+        if vm.isLoading {
+          LoadingSpinner()
+            .frame(width: 40, height: 40)
+        } else {
+          Button {
+            vm.addNewSection()
+          } label: {
+            VStack(spacing: 24) {
+              Image(.sectionAdd)
+              Text("파트를 추가해 보세요.")
+                .font(.headline2Medium)
+                .foregroundStyle(.secondaryAssitive)
+            }
           }
+          .disabled(vm.isEditing)
         }
       }
       .frame(maxWidth: .infinity)
@@ -162,14 +169,20 @@ struct SectionEditView: View {
         vm.addNewSection()
       } label: {
         HStack(spacing: 4) {
-          Image(systemName: "plus")
-            .font(.headline2SemiBold)
-            .foregroundStyle(.secondaryNormal)
-          Text("추가")
-            .font(.headline2SemiBold)
-            .foregroundStyle(.secondaryNormal)
+          if vm.isLoading {
+            LoadingSpinner()
+              .frame(width: 17, height: 17)
+          } else {
+            Image(systemName: "plus")
+              .font(.headline2SemiBold)
+              .foregroundStyle(vm.isEditing ? .fillAssitive : .secondaryNormal)
+            Text("추가")
+              .font(.headline2SemiBold)
+              .foregroundStyle(vm.isEditing ? .fillAssitive : .secondaryNormal)
+          }
         }
       }
+      .disabled(vm.isEditing || vm.isLoading)
     }
     .padding(.top, 32)
   }
@@ -217,21 +230,72 @@ struct SectionEditView: View {
   }
   
   private var bottomButton: some View {
-    ActionButton(
-      title: "확인",
-      color: vm.editText.isEmpty || vm.isLoading ? .fillAssitive : .secondaryStrong,
-      height: 47,
-      isEnabled: !vm.editText.isEmpty || vm.isLoading,
-      isLoading: vm.isLoading
-    ) {
-      if let sectionId = vm.editingSectionid,
-         let section = vm.sections.first(where: { $0.sectionId == sectionId }) {
-        Task {
-          await vm.updateSection(tracksId: tracksId, section: section)
+    ZStack {
+      ActionButton(
+        title: "확인",
+        color: vm.editText.isEmpty || vm.isLoading ? .fillAssitive : .secondaryStrong,
+        height: 47,
+        isEnabled: !vm.editText.isEmpty && !vm.isLoading,
+        isLoading: vm.isLoading
+      ) {
+        if let sectionId = vm.editingSectionid,
+           let section = vm.sections.first(where: { $0.sectionId == sectionId }) {
+          Task {
+            await vm.updateSection(tracksId: tracksId, section: section)
+
+            // 업데이트 성공 시에만 체크 애니메이션 표시
+            if !vm.isLoading { // isLoading이 false면 성공한 것
+              await MainActor.run {
+                checkEffectActive = true
+              }
+
+              try? await Task.sleep(for: .seconds(2.5))
+
+              await MainActor.run {
+                checkEffectActive = false
+              }
+            }
+          }
         }
       }
+      .opacity(checkEffectActive ? 0 : 1)
+
+      // 완료 체크 뷰
+      completedButtonView
     }
     .padding(.bottom, 8)
+  }
+
+  // MARK: - 섹션 저장 완료 뷰
+  private var completedButtonView: some View {
+    RoundedRectangle(cornerRadius: 15)
+      .fill(Color.fillAssitive)
+      .frame(height: 47)
+      .opacity(checkEffectActive ? 1 : 0)
+      .overlay {
+        HStack(spacing: 10) {
+          if #available(iOS 26.0, *) {
+            Image(systemName: "checkmark.circle")
+              .font(.system(size: 24, weight: .medium))
+              .foregroundStyle(Color.secondaryNormal)
+              .symbolEffect(
+                .drawOn,
+                options: .nonRepeating,
+                isActive: !checkEffectActive
+              )
+          } else {
+            Image(systemName: "checkmark.circle")
+              .font(.system(size: 24, weight: .medium))
+              .foregroundStyle(Color.secondaryNormal)
+              .opacity(checkEffectActive ? 1 : 0)
+          }
+
+          Text("파트를 저장했습니다.")
+            .font(.headline2SemiBold)
+            .foregroundStyle(Color.secondaryNormal)
+            .opacity(checkEffectActive ? 1 : 0)
+        }
+      }
   }
 }
 

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/SectionSelectView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/SectionSelectView.swift
@@ -87,6 +87,7 @@ struct SectionSelectView: View {
         }
       }
     )
+    .padding(.bottom, 8)
   }
 }
 

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/VideoListContent.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/VideoListContent.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct VideoListContent: View {
   let geometry: GeometryProxy
   let tracksId: String
+  let sectionId: String
   let videos: [Video]
   let track: [Track]
   let section: [Section]
@@ -30,6 +31,7 @@ struct VideoListContent: View {
       columns: columns,
       spacing: spacing,
       tracksId: tracksId,
+      sectionId: sectionId,
       videos: videos,
       track: track,
       section: section,

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/VideoListView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/VideoListView.swift
@@ -54,6 +54,7 @@ struct VideoListView: View {
           VideoListContent(
             geometry: geometry,
             tracksId: tracksId,
+            sectionId: vm.selectedSection?.sectionId ?? sectionId,
             videos: vm.filteredVideos,
             track: vm.track,
             section: vm.section,

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/VideoListView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/VideoListView.swift
@@ -210,6 +210,12 @@ struct VideoListView: View {
           .font(.headline2Medium)
           .foregroundStyle(.secondaryAssitive)
       }
+      .simultaneousGesture(
+        TapGesture()
+          .onEnded {
+            Task { await vm.requestPermissionAndFetch() }
+          }
+      )
     }
     .buttonStyle(.plain)
     .frame(width: g.size.width, height: g.size.height)

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/VideoTitleEditView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoList/VideoTitleEditView.swift
@@ -59,6 +59,8 @@ struct VideoTitleEditView: View {
         .frame(height: 47)
         .overlay {
           TextField("비디오 제목", text: $videoTitle)
+            .autocorrectionDisabled(true)
+            .textInputAutocapitalization(.never)
             .padding([.leading, .vertical], 16)
             .padding(.trailing, videoTitle.count >= 21 ? 20 : 16) // X버튼(44pt) 공간 확보
             .font(.headline2Medium)

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoPicker/VideoPickerView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoPicker/VideoPickerView.swift
@@ -55,7 +55,26 @@ struct VideoPickerView: View {
         }
         if vm.photoLibraryStatus == .authorized || vm.photoLibraryStatus == .limited {
           ToolbarItemGroup(placement: .topBarTrailing) {
-            trailingToolbar
+            VideoUploadButton(
+              isDisabled: vm.selectedAsset == nil,
+              action: {
+                if vm.selectedAsset == nil {
+                  self.showEmptyVideoAlert = true
+                  return
+                } else if vm.videoTitle == "" {
+                  self.isFocused = true
+                  return
+                } else if vm.videoTitle.count > 19 {
+                  self.showToast = true
+                  return
+                }
+                self.isFocused = false
+                // iCloud 다운로드 완료 후 피커 닫기
+                vm.exportVideo(tracksId: tracksId, sectionId: sectionId) {
+                  dismiss()
+                }
+              }
+            )
           }
         }
       }
@@ -78,17 +97,18 @@ struct VideoPickerView: View {
       let spacing: CGFloat = 1
       let totalSpacing = spacing * 2
       let itemWidth = (g.size.width - totalSpacing) / 4
-      
+      let previewHeight = g.size.width * 9 / 16
+
       ScrollViewReader { proxy in
         ScrollView {
           VStack(spacing: 16) {
             Color.clear
               .frame(height: 0)
               .id("TOP")
-            
+
             VideoPreview(
               vm: vm,
-              size: 224
+              size: previewHeight
             )
             
             textField
@@ -231,35 +251,6 @@ struct VideoPickerView: View {
         .font(.caption1Medium)
         .foregroundStyle(.labelNormal)
     }
-  }
-  // 커스텀 툴바 트레일링 버튼
-  // 영상 선택, 영상 제목 비어있을 때, 글자 수 케이스
-  private var trailingToolbar: some View {
-    Button {
-      if vm.selectedAsset == nil {
-        self.showEmptyVideoAlert = true
-        return
-      } else if vm.videoTitle == "" {
-        self.isFocused = true
-        return
-      } else if vm.videoTitle.count > 19 {
-        self.showToast = true
-        return
-      }
-      self.isFocused = false
-      // iCloud 다운로드 완료 후 피커 닫기
-      vm.exportVideo(tracksId: tracksId, sectionId: sectionId) {
-        dismiss()
-      }
-    } label: {
-      Image(systemName: "arrow.up")
-        .foregroundStyle(
-          vm.selectedAsset == nil ? Color.labelAssitive : Color.labelStrong
-        )
-    }
-    .disabled(vm.selectedAsset == nil)
-    .buttonStyle(.borderedProminent)
-    .tint(Color.secondaryStrong)
   }
 }
 

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoPicker/VideoPreview.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoPicker/VideoPreview.swift
@@ -61,17 +61,6 @@ struct VideoPreview: View {
     })
     .ignoresSafeArea()
   }
-  
-  private var loadingView: some View {
-    VStack {
-      ProgressView()
-        .tint(.white)
-        .scaleEffect(1.5)
-      Text("로딩 중...")
-        .foregroundStyle(.white)
-        .padding(.top)
-    }
-  }
 }
 //#Preview {
 //  NavigationStack {

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoPicker/VideoUploadButton.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoPicker/VideoUploadButton.swift
@@ -1,0 +1,45 @@
+//
+//  VideoUploadButton.swift
+//  DanceMachine
+//
+//  Created by Claude on 11/24/25.
+//
+
+import SwiftUI
+
+struct VideoUploadButton: View {
+  let isDisabled: Bool
+  let action: () -> Void
+
+  var body: some View {
+    if #available(iOS 26.0, *) {
+      Button {
+        action()
+      } label: {
+        Image(systemName: "arrow.up")
+          .foregroundStyle(
+            isDisabled ? Color.labelAssitive : Color.labelStrong
+          )
+      }
+      .disabled(isDisabled)
+      .buttonStyle(.borderedProminent)
+      .tint(Color.secondaryStrong)
+      .environment(\.colorScheme, .light)
+    } else {
+      Button {
+        action()
+      } label: {
+        ZStack {
+          Circle().fill(Color.secondaryNormal)
+            .frame(width: 44, height: 44)
+          Image(systemName: "arrow.up")
+            .foregroundStyle(
+              isDisabled ? Color.labelAssitive : Color.labelStrong
+            )
+        }
+      }
+      .disabled(isDisabled)
+      .environment(\.colorScheme, .light)
+    }
+  }
+}

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/Feedback/FeedbackInPutView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/Feedback/FeedbackInPutView.swift
@@ -138,6 +138,12 @@ struct FeedbackInPutView: View {
               .font(.footnoteMedium)
               .foregroundStyle(.labelStrong)
           }
+          .simultaneousGesture(
+            TapGesture()
+              .onEnded {
+                drawingButtonTapped()
+              }
+          )
           .padding(.vertical, 7)
           .padding(.horizontal, 10)
         }
@@ -159,6 +165,12 @@ struct FeedbackInPutView: View {
       Image(systemName: "xmark")
         .font(.system(size: 17))
         .foregroundStyle(.labelNormal)
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              refresh()
+            }
+        )
     }
   }
   
@@ -172,12 +184,21 @@ struct FeedbackInPutView: View {
           .frame(width: 30, height: 30)
           .clipShape(RoundedRectangle(cornerRadius: 100))
           .matchedGeometryEffect(id: "feedbackImage", in: imageNamespace)
-          .onTapGesture {
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
-//              showImageFull = true
-              self.editDrawingTapped() // 기존 이미지를 시트에 전달
-            }
-          }
+          .simultaneousGesture(
+            TapGesture()
+              .onEnded {
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+    //              showImageFull = true
+                  self.editDrawingTapped() // 기존 이미지를 시트에 전달
+                }
+              }
+          )
+//          .onTapGesture {
+//            withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+////              showImageFull = true
+//              self.editDrawingTapped() // 기존 이미지를 시트에 전달
+//            }
+//          }
       }
     }
   }

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/Feedback/FeedbackSection.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/Feedback/FeedbackSection.swift
@@ -17,12 +17,12 @@ struct FeedbackSection: View {
         .foregroundStyle(.labelStrong)
       Spacer()
       Button {
-        switch feedbackFilter {
-        case .all:
-          self.feedbackFilter = .mine
-        case .mine:
-          self.feedbackFilter = .all
-        }
+//        switch feedbackFilter {
+//        case .all:
+//          self.feedbackFilter = .mine
+//        case .mine:
+//          self.feedbackFilter = .all
+//        }
       } label: {
         Text("마이피드백")
           .foregroundStyle(feedbackFilter == .all ? .secondaryAssitive : .labelStrong)
@@ -32,6 +32,17 @@ struct FeedbackSection: View {
             RoundedRectangle(cornerRadius: 10)
               .fill(feedbackFilter == .all ? .backgroundElevated : .secondaryStrong)
               .stroke(feedbackFilter == .all ? .secondaryAssitive : .secondaryNormal)
+          )
+          .simultaneousGesture(
+            TapGesture()
+              .onEnded {
+                switch feedbackFilter {
+                case .all:
+                  self.feedbackFilter = .mine
+                case .mine:
+                  self.feedbackFilter = .all
+                }
+              }
           )
       }
     }

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/FeedbackContainer.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/FeedbackContainer.swift
@@ -69,12 +69,21 @@ struct FeedbackContainer: View {
     }
     .background(Color.backgroundNormal)
     .contentShape(Rectangle())
-    .onTapGesture {
-      if state.showFeedbackInput {
-        state.showFeedbackInput = false
-        dismissKeyboard()
-      }
-    }
+    .simultaneousGesture(
+      TapGesture()
+        .onEnded {
+          if state.showFeedbackInput {
+            state.showFeedbackInput = false
+            dismissKeyboard()
+          }
+        }
+    )
+//    .onTapGesture {
+//      if state.showFeedbackInput {
+//        state.showFeedbackInput = false
+//        dismissKeyboard()
+//      }
+//    }
     .safeAreaInset(edge: .bottom) {
       if state.isImageOverlayPresented {
         EmptyView()

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/PaperDrawing/iOS18-/Helpers/FeedbackPencilDrawingView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/PaperDrawing/iOS18-/Helpers/FeedbackPencilDrawingView.swift
@@ -38,7 +38,7 @@ struct FeedbackPencilDrawingView: View {
       ZStack {
         Color.black.ignoresSafeArea()
         VStack(spacing: 4) {
-          drawingToolbar.padding(.horizontal, 16)
+          drawingToolbar
           PencilCanvasView(
             canvasView: $canvasView,
             tool: selectedTool,
@@ -106,7 +106,7 @@ struct FeedbackPencilDrawingView: View {
   
   // MARK: - 탑 타이틀
   private var drawingToolbar: some View {
-    HStack(spacing: 12) {
+    HStack {
       // X 버튼
       Button {
         dismiss()
@@ -117,13 +117,12 @@ struct FeedbackPencilDrawingView: View {
       }
       .frame(width: 44, height: 44)
       .drawingButton()
-
-      Spacer()
+      
 
       // 버튼 그룹들
-      HStack(spacing: 12) {
+      HStack {
         // 그룹 1: Undo/Redo
-        HStack(spacing: 0) {
+        HStack(spacing: 12) {
           Button {
             undoDrawing()
           } label: {
@@ -155,6 +154,8 @@ struct FeedbackPencilDrawingView: View {
         }
         .frame(width: 44, height: 44)
         .drawingButton()
+        
+        Spacer()
 
         // 그룹 3: 완료
         Button {
@@ -165,13 +166,14 @@ struct FeedbackPencilDrawingView: View {
           }
         } label: {
           Image(systemName: "checkmark")
-            .font(.system(size: 22, weight: .semibold))
-            .foregroundStyle(Color.white)
+            .font(.system(size: 22, weight: .medium))
+            .foregroundStyle(Color.labelStrong)
         }
         .frame(width: 44, height: 44)
         .drawingSubmitButton()
       }
     }
+    .padding(.horizontal, 16)
   }
   
   /// 팬슬 이전 그림 취소하는 기능입니다.

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/PaperDrawing/iOS26+/Helpers/FeedbackPaperDrawingView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/PaperDrawing/iOS26+/Helpers/FeedbackPaperDrawingView.swift
@@ -34,7 +34,7 @@ struct FeedbackPaperDrawingView: View {
     ZStack {
       Color.black.ignoresSafeArea()
       VStack {
-        topTitleView.padding(.horizontal, 16)
+        topTitleView
         drawingView
       }
     }
@@ -57,7 +57,7 @@ struct FeedbackPaperDrawingView: View {
   
   // MARK: - 탑 타이틀
   private var topTitleView: some View {
-    HStack(spacing: 12) {
+    HStack {
       // X 버튼
       Button {
         dismiss()
@@ -68,13 +68,12 @@ struct FeedbackPaperDrawingView: View {
       }
       .frame(width: 44, height: 44)
       .drawingButton()
-
-      Spacer()
+      
 
       // 버튼 그룹들
-      HStack(spacing: 12) {
+      HStack {
         // 그룹 1: Undo/Redo
-        HStack(spacing: 0) {
+        HStack(spacing: 12) {
           Button {
             self.feedbackPaperDrawingData.undo()
           } label: {
@@ -139,7 +138,7 @@ struct FeedbackPaperDrawingView: View {
         }
         .padding(.horizontal, 4)
         .drawingButtonGroup()
-
+        Spacer()
         // 그룹 3: 완료
         Button {
           Task { @MainActor in

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/Reply/ReplyInputView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/Reply/ReplyInputView.swift
@@ -114,6 +114,12 @@ struct ReplyRecycle: View {
       Image(systemName: "xmark")
         .font(.system(size: 17))
         .foregroundStyle(.labelNormal)
+        .simultaneousGesture(
+          TapGesture()
+            .onEnded {
+              refresh()
+            }
+        )
     }
   }
 }

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/Reply/ReplySheet.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/Reply/ReplySheet.swift
@@ -83,7 +83,7 @@ struct ReplySheet: View {
         onBottomReplyTap: {
           self.inputMode = .reply
         },
-        imageNamespace: imageNamespace,
+        imageNamespace: nil,
         onImageTap: { url in
           onImageTap(url)
           dismiss()

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/Reply/ReplySheet.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/Reply/ReplySheet.swift
@@ -92,11 +92,19 @@ struct ReplySheet: View {
       replyList
     }
     .contentShape(Rectangle())
-    .onTapGesture {
-      /// 키보드 내리면서 들어가있는 모든 내용들을 초기화 하는 내용입니다.
-      self.inputMode = .none
-      mM.dismissKeyboardAndClear()
-    }
+    .simultaneousGesture(
+      TapGesture()
+        .onEnded {
+          /// 키보드 내리면서 들어가있는 모든 내용들을 초기화 하는 내용입니다.
+          self.inputMode = .none
+          mM.dismissKeyboardAndClear()
+        }
+    )
+//    .onTapGesture {
+//      /// 키보드 내리면서 들어가있는 모든 내용들을 초기화 하는 내용입니다.
+//      self.inputMode = .none
+//      mM.dismissKeyboardAndClear()
+//    }
     .animation(.easeInOut(duration: 0.2), value: mM.showPicker)
     .safeAreaInset(edge: .bottom) {
       switch inputMode {

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/VideoPlayerContainer.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/VideoPlayerContainer.swift
@@ -55,9 +55,16 @@ struct VideoPlayerContainer: View {
       GeometryReader { g in
         Color.clear
           .contentShape(Rectangle())
-          .onTapGesture { location in
-            self.handleTap(location: location, width: g.size.width)
-          }
+          .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+              .onEnded { value in
+                self.handleTap(
+                  location: value.location,
+                  width: g.size.width,
+                  height: g.size.height
+                )
+              }
+          )
       }
       .gesture(magnificationGesture)
       .simultaneousGesture(dragGesture)
@@ -161,7 +168,7 @@ struct VideoPlayerContainer: View {
           showFeedbackPanel: showFeedbackPanel,
           drawingAction: onDrawingAction
         )
-        .padding(.vertical, isIPad && isLandscapeMode ? 40 : 0)
+//        .padding(.vertical, isIPad && isLandscapeMode ? 55 : 0)
         .padding(.horizontal, isLandscapeMode && !showFeedbackPanel ? 24 : 0)
         .onChange(of: vm.videoVM.currentTime) { _, newValue in
           if !state.isDragging {
@@ -206,7 +213,13 @@ struct VideoPlayerContainer: View {
     }
   }
   
-  private func handleTap(location: CGPoint, width: CGFloat) {
+  private func handleTap(location: CGPoint, width: CGFloat, height: CGFloat) {
+    // iPad 가로모드에서 상단 버튼 영역 제외 (VideoSettingButtons, FeedbackSection)
+    let isIPadLandscape = UIDevice.current.userInterfaceIdiom == .pad && isLandscapeMode
+    if isIPadLandscape && location.y < 100 {
+      return // 상단 100pt는 버튼 영역이므로 탭 무시
+    }
+
     if location.x < width / 3 {
       vm.videoVM.leftTab()
     } else if location.x > width * 2 / 3 {

--- a/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/iPadVideoView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Home/Views/VideoView/iPadVideoView.swift
@@ -75,7 +75,7 @@ struct iPadVideoView: View {
       }
     }
     .animation(.spring(response: 0.3, dampingFraction: 0.7), value: state.showSpeedSheet)
-    .toolbarTitleDisplayMode(.inline)
+//    .toolbarTitleDisplayMode(.inline)
     .toolbar {
       if !state.iPadShowFullScreen {
         ToolbarLeadingBackButton(icon: .chevron)
@@ -104,8 +104,6 @@ struct iPadVideoView: View {
   @ViewBuilder
   private var landscapeView: some View {
     NavigationSplitView(columnVisibility: $columnVisibility) {
-      ZStack {
-//        Color.black.ignoresSafeArea(edges: .top, .bottom)
 
         VideoPlayerContainer(
           vm: vm,
@@ -139,9 +137,9 @@ struct iPadVideoView: View {
           }
         )
         .offset(y: state.dragOffset * 0.5)
-      }
-      .ignoresSafeArea(.all, edges: .top)
-      .navigationSplitViewColumnWidth(min: 600, ideal: 800, max: 1000)
+//        .contentShape(.interaction, Rectangle())
+//        .ignoresSafeArea(.all, edges: .top)
+        .navigationSplitViewColumnWidth(min: 600, ideal: 800, max: 1000)
     } detail: {
         FeedbackContainer(
           vm: vm,
@@ -149,7 +147,7 @@ struct iPadVideoView: View {
           videoId: videoId,
           userId: userId,
           filteredFeedbacks: filteredFeedbacks,
-          iPadLandscape: true,
+          iPadLandscape: false,
           drawingImageNamespace: drawingImageNamespace,
           feedbackImageNamespace: feedbackImageNamespace,
           onDrawingAction: onCaptureFrame,
@@ -157,7 +155,8 @@ struct iPadVideoView: View {
           onFeedbackSelect: nil,
           isSidebarVisible: columnVisibility == .all
         )
-        .ignoresSafeArea(.all, edges: .top)
+//        .contentShape(.interaction, Rectangle())
+//        .ignoresSafeArea(.all, edges: .top)
         .navigationSplitViewColumnWidth(min: 350, ideal: 450, max: 600)
     }
     .navigationSplitViewStyle(.balanced)

--- a/DanceMachine/DanceMachine/Resource/Extension/View+.swift
+++ b/DanceMachine/DanceMachine/Resource/Extension/View+.swift
@@ -288,7 +288,7 @@ extension View {
         .background {
           Circle()
             .fill(Color.secondaryStrong)
-            .shadow(color: .white.opacity(0.3), radius: 2, x: 0, y: 1)
+            .shadow(color: .white.opacity(0.25), radius: 2, x: 0, y: 1)
         }
     }
   }

--- a/DanceMachine/DanceMachine/Service/FireStorageManager.swift
+++ b/DanceMachine/DanceMachine/Service/FireStorageManager.swift
@@ -30,7 +30,7 @@ final class FireStorageManager {
     data: Data,
     type: StorageType,
     progressHandler: ((Double) -> Void)? = nil,
-    timeout: TimeInterval = 60.0
+    timeout: TimeInterval = 300.0 // 5분 경과 시 네트워크 에러 throw
   ) async throws -> String {
     
     let path = type.path

--- a/DanceMachine/DanceMachine/Service/VideoProgressManager.swift
+++ b/DanceMachine/DanceMachine/Service/VideoProgressManager.swift
@@ -26,8 +26,13 @@ final class VideoProgressManager {
   }
 
   var uploadState: UploadState = .idle
-  
-  func startCompressing() {
+
+  var currentTracksId: String?
+  var currentSectionId: String?
+
+  func startCompressing(tracksId: String, sectionId: String) {
+    self.currentTracksId = tracksId
+    self.currentSectionId = sectionId
     uploadState = .compressing(progress: 0.0)
   }
   
@@ -36,7 +41,9 @@ final class VideoProgressManager {
     uploadState = .compressing(progress: progress)
   }
 
-  func startUpload() {
+  func startUpload(tracksId: String, sectionId: String) {
+    self.currentTracksId = tracksId
+    self.currentSectionId = sectionId
     uploadState = .uploading(progress: 0.0)
   }
 
@@ -47,6 +54,8 @@ final class VideoProgressManager {
 
   func finishUpload() {
     uploadState = .idle
+    currentTracksId = nil
+    currentSectionId = nil
   }
 
   func failUpload(message: String) {
@@ -55,5 +64,7 @@ final class VideoProgressManager {
 
   func reset() {
     uploadState = .idle
+    currentTracksId = nil
+    currentSectionId = nil
   }
 }


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🛠️ 작업내용
*****QA 반영 사항 ******
1. 드로잉 뷰 상단 버튼 레이아웃 조정
2. 파트 추가 중복 방지
3. 영상 업로드 버탄, 피커 업로드 버튼 디자인 통일 (18버전 다르게 보여서 분기처리함)
4. 업로드 스켈레톤뷰 로딩뷰와 같이 들어가는 사항 수정 (업로드중 새로고침하면 같이 추가되서 보임)
5. 업로드 스켈레톤뷰 다른 파트에서는 안보이게 수정(해당섹션 업로드 카드는 해당 섹셕만 필터해서 볼 수 있게 수정함)

******iPad 수정********
- 아이패드 스플릿뷰 버그가 많아서 레이아웃 조정 했습니다
- simultaneousGesture 로 모든 터치영역을 변경하였습니다.
- onTapGesture는 아예 변경, button은 버튼의 액션 일단 빼고 라벨에 달아줬습니다 (두번 액션함)
-> 그래도 가로뷰에서 스플릿뷰를 닫는 윗 라인쪽 터치 전멸이라 레이아웃을 전체적으로 내렸습니다 

## 📋 시연 영상





