### PR TITLE
Fix/#168 계정 복구 기능

### DIFF
--- a/DanceMachine/DanceMachine.xcodeproj/project.pbxproj
+++ b/DanceMachine/DanceMachine.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.6;
+				MARKETING_VERSION = 1.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.VelKaJeJulLiPa.DanceMachine;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -363,7 +363,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.6;
+				MARKETING_VERSION = 1.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.VelKaJeJulLiPa.DanceMachine;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/DanceMachine/DanceMachine.xcodeproj/project.pbxproj
+++ b/DanceMachine/DanceMachine.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.VelKaJeJulLiPa.DanceMachine;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -363,7 +363,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.5;
+				MARKETING_VERSION = 1.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.VelKaJeJulLiPa.DanceMachine;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/DanceMachine/DanceMachine/Models/DTO/MainCollection/User.swift
+++ b/DanceMachine/DanceMachine/Models/DTO/MainCollection/User.swift
@@ -9,7 +9,7 @@ import Foundation
 import FirebaseAuth
 
 struct User: Codable, Equatable {
-  
+
   let userId: String
   let email: String
   let name: String
@@ -18,8 +18,9 @@ struct User: Codable, Equatable {
   let fcmToken: String
   let termsAgreed: Bool
   let privacyAgreed: Bool
+  let country: String
   var updatedAt: Date?
-  
+
   init(
     userId: String,
     email: String,
@@ -29,8 +30,8 @@ struct User: Codable, Equatable {
     fcmToken: String,
     termsAgreed: Bool,
     privacyAgreed: Bool,
-    updatedAt: Date? = nil,
-    
+    country: String = User.detectCountryFromLocale(),
+    updatedAt: Date? = nil
   ) {
     self.userId = userId
     self.email = email
@@ -40,10 +41,27 @@ struct User: Codable, Equatable {
     self.fcmToken = fcmToken
     self.termsAgreed = termsAgreed
     self.privacyAgreed = privacyAgreed
+    self.country = country
     self.updatedAt = updatedAt
-    
   }
-  
+
+  /// 기기 Locale에서 국가 코드 감지
+  /// - Returns: 소문자 국가 코드 (kr, us, jp) - 지원하지 않는 국가는 "kr" 반환
+  static func detectCountryFromLocale() -> String {
+    let regionCode = Locale.current.region?.identifier ?? "KR"
+    let countryCode = regionCode.lowercased()
+
+    // 지원하는 국가 목록
+    let supportedCountries = ["kr", "us", "jp"]
+
+    if supportedCountries.contains(countryCode) {
+      return countryCode
+    } else {
+      // 지원하지 않는 국가는 기본값 "kr"
+      return "kr"
+    }
+  }
+
   enum CodingKeys: String, CodingKey {
     case userId = "user_id"
     case email
@@ -53,8 +71,26 @@ struct User: Codable, Equatable {
     case fcmToken = "fcm_token"
     case termsAgreed = "terms_agreed"
     case privacyAgreed = "privacy_agreed"
+    case country
     case updatedAt     = "updated_at"
-    
+  }
+
+  // Custom decoder: country 필드가 없으면 자동 감지
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    userId = try container.decode(String.self, forKey: .userId)
+    email = try container.decode(String.self, forKey: .email)
+    name = try container.decode(String.self, forKey: .name)
+    loginType = try container.decode(String.self, forKey: .loginType)
+    status = try container.decode(String.self, forKey: .status)
+    fcmToken = try container.decode(String.self, forKey: .fcmToken)
+    termsAgreed = try container.decode(Bool.self, forKey: .termsAgreed)
+    privacyAgreed = try container.decode(Bool.self, forKey: .privacyAgreed)
+
+    // country 필드가 없으면 자동 감지
+    country = try container.decodeIfPresent(String.self, forKey: .country) ?? User.detectCountryFromLocale()
+
+    updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
   }
 }
 

--- a/DanceMachine/DanceMachine/Navigation/MainNavigationRoutingView.swift
+++ b/DanceMachine/DanceMachine/Navigation/MainNavigationRoutingView.swift
@@ -33,6 +33,8 @@ struct MainNavigationRoutingView: View {
           TermsOfUseView()
         case .accountSetting:
           AccountSettingView()
+        case .accountRecovery:
+          AccountRecoveryView()
         case .appMaker:
           AppMakerView()
         }

--- a/DanceMachine/DanceMachine/Navigation/NavigationDestination.swift
+++ b/DanceMachine/DanceMachine/Navigation/NavigationDestination.swift
@@ -64,6 +64,7 @@ enum MyPageRoute: Hashable {
   case privacyPolicy
   case termsOfUse
   case accountSetting
+  case accountRecovery
   case appMaker
 }
 

--- a/DanceMachine/DanceMachine/Presentations/Login/ViewModels/LoginViewModel.swift
+++ b/DanceMachine/DanceMachine/Presentations/Login/ViewModels/LoginViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 import AuthenticationServices
 import FirebaseAuth
 import FirebaseFirestore
+import FirebaseFunctions
 
 
 final class LoginViewModel: ObservableObject {
@@ -20,69 +21,131 @@ final class LoginViewModel: ObservableObject {
   @Published var adminLoginError: String? = nil
   @Published var adminLoginSuccess: Bool = false
   
-  /// 애플 로그인을 담담하는 메서드
+  /// 애플 로그인을 담당하는 메서드
   /// - SigninwithAppleHelper 파일에서 소셜 로그인 플로우를 담당
   /// - 애플에서 제공해주는 사용자 정보로 Firebase Authentication 계정 생성
   /// - DB에 사용자 정보가 있으면, 사용자 정보를 세팅하고 authenticated 상태로 전환
   /// - DB에 사용자 정보가 없으면, 신규 회원이므로, 이용약관으로 화면 이동
   func signInApple() async throws {
+    print("🚀 [LoginViewModel] signInApple 시작")
     isLoading = true
     FirebaseAuthManager.shared.isSigningIn = true
-    
-    defer { isLoading = false }
-    
+
+    defer {
+      isLoading = false
+      print("✅ [LoginViewModel] signInApple 종료 - isNewUser: \(isNewUser)")
+    }
+
     do {
+      // 1. Apple Sign-In
+      print("📱 [LoginViewModel] Apple Sign-In 시작")
       let helper = SignInAppleHelper()
       let tokens = try await helper.startSignInWithAppleFlow()
+
+      // 2. Firebase Authentication
+      print("🔐 [LoginViewModel] Firebase Authentication 시작")
       let authDataResult = try await FirebaseAuthManager.shared.signInWithApple(tokens: tokens)
       FirebaseAuthManager.shared.user = Auth.auth().currentUser
-      
-      let fcmToken = UserDefaults.standard.string(forKey: UserDefaultsKey.fcmToken.rawValue) ?? "Unknown"
-      
-      let user = User(userId: authDataResult.user.uid,
-                      email: authDataResult.user.email ?? "Unknown",
-                      name: FirebaseAuthManager.shared.displayName(from: authDataResult.user.displayName),
-                      loginType: LoginType.apple,
-                      status: UserStatus.active,
-                      fcmToken: fcmToken,
-                      termsAgreed: true,
-                      privacyAgreed: true)
-      
-      let existingUser: User? = try? await FirestoreManager.shared.get(user.userId, from: .users)
-      if existingUser != nil {
-        isNewUser = false
-        try await FirestoreManager.shared.updateLastLoginFields(
-          collection: .users,
-          documentId: user.userId,
-          asDictionary: [
-            User.CodingKeys.fcmToken.rawValue: fcmToken,
-            User.CodingKeys.updatedAt.rawValue: FieldValue.serverTimestamp()
-          ]
+
+      let uid = authDataResult.user.uid
+      let fcmToken = UserDefaults.standard.string(forKey: UserDefaultsKey.fcmToken.rawValue) ?? ""
+
+      print("✅ [LoginViewModel] Firebase UID: \(uid)")
+      print("   FCM Token: \(fcmToken.isEmpty ? "없음" : "있음")")
+
+      // 2-1. transfer_sub 확인 및 Migration 시도
+      if let transferSub = tokens.transferSub {
+        print("🔄 [LoginViewModel] transfer_sub 감지 - Migration 시도")
+        await attemptMigration(
+          transferSub: transferSub,
+          currentUid: uid,
+          email: authDataResult.user.email,
+          name: FirebaseAuthManager.shared.displayName(from: authDataResult.user.displayName),
+          fcmToken: fcmToken
         )
-        let userInfo: User = try await FirestoreManager.shared.get(user.userId, from: .users)
-        FirebaseAuthManager.shared.userInfo = userInfo
+        // Migration 후 return (함수 내에서 로그인 완료 처리)
+        return
+      }
+
+      // 3. 기존 유저 확인 (명시적 에러 처리)
+      print("🔍 [LoginViewModel] Firestore에서 기존 유저 조회 시작")
+
+      do {
+        let existingUser: User = try await FirestoreManager.shared.get(uid, from: .users)
+
+        // 기존 유저 확정
+        print("✅ [LoginViewModel] 기존 유저 확인")
+        print("   이름: \(existingUser.name)")
+        print("   이메일: \(existingUser.email)")
+
+        isNewUser = false
+
+        // FCM 토큰만 업데이트
+        if !fcmToken.isEmpty {
+          print("📱 [LoginViewModel] FCM 토큰 업데이트 중")
+          try await FirestoreManager.shared.updateLastLoginFields(
+            collection: .users,
+            documentId: uid,
+            asDictionary: [
+              User.CodingKeys.fcmToken.rawValue: fcmToken,
+              User.CodingKeys.updatedAt.rawValue: FieldValue.serverTimestamp()
+            ]
+          )
+        }
+
+        // ⚠️ 중요: 기존 조회한 existingUser 사용 (재조회 불필요)
+        FirebaseAuthManager.shared.userInfo = existingUser
         FirebaseAuthManager.shared.didCompleteAuthFlow = true
         FirebaseAuthManager.shared.isSigningIn = false
         FirebaseAuthManager.shared.authenticationState = .authenticated
-      } else {
-        FirebaseAuthManager.shared.userInfo = user
+
+        print("✅ [LoginViewModel] 기존 유저 로그인 완료")
+
+      } catch {
+        // Firestore 조회 실패 → 신규 유저
+        print("ℹ️ [LoginViewModel] Firestore에서 유저 없음 → 신규 유저")
+        print("   에러: \(error.localizedDescription)")
+
         isNewUser = true
+
+        // ⚠️ 중요: 신규 유저용 임시 User 객체 생성
+        // 주의: email과 name이 빈 문자열일 수 있음 (회원가입 화면에서 처리)
+        let tempUser = User(
+          userId: uid,
+          email: authDataResult.user.email ?? "",  // ← 빈 문자열 허용 (NameSettingViewModel에서 검증)
+          name: FirebaseAuthManager.shared.displayName(from: authDataResult.user.displayName),
+          loginType: LoginType.apple,
+          status: UserStatus.active,
+          fcmToken: fcmToken,
+          termsAgreed: true,
+          privacyAgreed: true
+        )
+
+        print("📝 [LoginViewModel] 신규 유저 임시 객체 생성")
+        print("   email: \(tempUser.email.isEmpty ? "(빈 문자열)" : tempUser.email)")
+        print("   name: \(tempUser.name.isEmpty ? "(빈 문자열)" : tempUser.name)")
+        print("   ⚠️ 이 객체는 Firestore에 저장되지 않음 (회원가입 플로우에서 처리)")
+
+        // 임시로 userInfo 설정 (회원가입 완료 시 정식 저장)
+        FirebaseAuthManager.shared.userInfo = tempUser
       }
-      print("signInApple done with authenticationState updated")
+
     } catch {
+      print("❌ [LoginViewModel] signInApple 실패: \(error.localizedDescription)")
+      FirebaseAuthManager.shared.isSigningIn = false
       showError = true
       throw error
     }
   }
   
   func signInWithEmail(email: String, password: String) async {
-    
+
     await MainActor.run {
       self.isLoading = true
       self.adminLoginError = nil
       self.adminLoginSuccess = false
     }
-    
+
     do {
       try await FirebaseAuthManager.shared.signInWithEmail(
         email: email,
@@ -91,11 +154,159 @@ final class LoginViewModel: ObservableObject {
       // 로그인 성공
       self.isLoading = false
       self.adminLoginSuccess = true
-      
+
     } catch {
       self.isLoading = false
       self.adminLoginError = "로그인 실패: 계정 정보를 확인해 주세요."
     }
-    
+
+  }
+
+  /// Apple Sign-In Migration 시도
+  /// - Parameters:
+  ///   - transferSub: Apple Transfer Identifier
+  ///   - currentUid: 현재 Firebase UID
+  ///   - email: 사용자 이메일 (옵션)
+  ///   - name: 사용자 이름 (옵션)
+  ///   - fcmToken: FCM 토큰
+  private func attemptMigration(
+    transferSub: String,
+    currentUid: String,
+    email: String?,
+    name: String,
+    fcmToken: String
+  ) async {
+    print("🔄 [LoginViewModel] Migration 시작")
+    print("   transferSub: \(transferSub)")
+    print("   currentUid: \(currentUid)")
+    print("   email: \(email ?? "(nil)")")
+    print("   name: \(name)")
+
+    do {
+      // Firebase Functions 호출
+      let functions = Functions.functions(region: "asia-northeast3")
+      let callable = functions.httpsCallable("migrateAppleUser")
+
+      let data: [String: Any] = [
+        "transferSub": transferSub,
+        "currentUid": currentUid,
+        "email": email ?? "",
+        "name": name
+      ]
+
+      print("📡 [LoginViewModel] Functions 호출 중...")
+      let result = try await callable.call(data)
+
+      guard let response = result.data as? [String: Any],
+            let success = response["success"] as? Bool else {
+        print("❌ [LoginViewModel] Migration 응답 형식 오류")
+        print("   response: \(result.data)")
+        // Migration 실패 시 정상 플로우로 진행 (신규 유저로 처리)
+        await handleMigrationFailure(currentUid: currentUid, email: email, name: name, fcmToken: fcmToken)
+        return
+      }
+
+      if success {
+        // Migration 성공!
+        guard let migratedFrom = response["migratedFrom"] as? String else {
+          print("❌ [LoginViewModel] migratedFrom 없음")
+          await handleMigrationFailure(currentUid: currentUid, email: email, name: name, fcmToken: fcmToken)
+          return
+        }
+
+        print("✅ [LoginViewModel] Migration 성공!")
+        print("   기존 UID: \(migratedFrom)")
+        print("   현재 UID: \(currentUid)")
+
+        // 기존 UID로 사용자 정보 조회
+        let existingUser: User = try await FirestoreManager.shared.get(migratedFrom, from: .users)
+
+        print("✅ [LoginViewModel] 기존 유저 데이터 조회 성공")
+        print("   이름: \(existingUser.name)")
+        print("   이메일: \(existingUser.email)")
+
+        // FCM 토큰 업데이트
+        if !fcmToken.isEmpty {
+          print("📱 [LoginViewModel] FCM 토큰 업데이트 중")
+          try await FirestoreManager.shared.updateLastLoginFields(
+            collection: .users,
+            documentId: migratedFrom,
+            asDictionary: [
+              User.CodingKeys.fcmToken.rawValue: fcmToken,
+              User.CodingKeys.updatedAt.rawValue: FieldValue.serverTimestamp()
+            ]
+          )
+        }
+
+        // 로그인 완료 처리
+        FirebaseAuthManager.shared.userInfo = existingUser
+        FirebaseAuthManager.shared.didCompleteAuthFlow = true
+        FirebaseAuthManager.shared.isSigningIn = false
+        FirebaseAuthManager.shared.authenticationState = .authenticated
+
+        await MainActor.run {
+          self.isNewUser = false
+        }
+
+        print("✅ [LoginViewModel] Migration 로그인 완료")
+
+      } else {
+        // Migration 실패 (기존 유저 없음)
+        print("⚠️ [LoginViewModel] Migration 실패: 기존 유저 없음")
+        print("   message: \(response["message"] as? String ?? "unknown")")
+        await handleMigrationFailure(currentUid: currentUid, email: email, name: name, fcmToken: fcmToken)
+      }
+
+    } catch {
+      print("❌ [LoginViewModel] Migration 호출 실패: \(error.localizedDescription)")
+      await handleMigrationFailure(currentUid: currentUid, email: email, name: name, fcmToken: fcmToken)
+    }
+  }
+
+  /// Migration 실패 시 정상 플로우로 진행 (신규 유저 처리)
+  private func handleMigrationFailure(
+    currentUid: String,
+    email: String?,
+    name: String,
+    fcmToken: String
+  ) async {
+    print("ℹ️ [LoginViewModel] 정상 플로우로 진행 (신규 유저)")
+
+    // Firestore에서 currentUid로 기존 유저 확인
+    do {
+      let existingUser: User = try await FirestoreManager.shared.get(currentUid, from: .users)
+
+      // 이미 가입된 유저
+      print("✅ [LoginViewModel] 기존 유저 확인 (Migration 없이)")
+      FirebaseAuthManager.shared.userInfo = existingUser
+      FirebaseAuthManager.shared.didCompleteAuthFlow = true
+      FirebaseAuthManager.shared.isSigningIn = false
+      FirebaseAuthManager.shared.authenticationState = .authenticated
+
+      await MainActor.run {
+        self.isNewUser = false
+      }
+
+    } catch {
+      // 신규 유저
+      print("ℹ️ [LoginViewModel] 신규 유저로 처리")
+
+      let tempUser = User(
+        userId: currentUid,
+        email: email ?? "",
+        name: name,
+        loginType: LoginType.apple,
+        status: UserStatus.active,
+        fcmToken: fcmToken,
+        termsAgreed: true,
+        privacyAgreed: true
+      )
+
+      FirebaseAuthManager.shared.userInfo = tempUser
+
+      await MainActor.run {
+        self.isNewUser = true
+      }
+    }
   }
 }

--- a/DanceMachine/DanceMachine/Presentations/Login/ViewModels/NameSettingViewModel.swift
+++ b/DanceMachine/DanceMachine/Presentations/Login/ViewModels/NameSettingViewModel.swift
@@ -40,17 +40,73 @@ final class NameSettingViewModel {
   }
   
   
-  func createNewuser() async throws {
+  /// 신규 사용자를 Firestore에 생성하는 메서드
+  /// - Parameters:
+  ///     - name: 사용자가 TextField에서 입력한 이름
+  func createNewuser(name: String) async throws {
+    print("🆕 [NameSettingViewModel] createNewuser 시작")
+    print("   입력된 이름: \(name)")
+
     isLoading = true
     defer { isLoading = false }
-    
+
     guard let userInfo = authManager.userInfo else {
+      print("❌ [NameSettingViewModel] authManager.userInfo가 nil")
       throw AuthenticationError.userNotFound
     }
-    
+
+    print("📋 [NameSettingViewModel] 현재 userInfo:")
+    print("   userId: \(userInfo.userId)")
+    print("   email: \(userInfo.email.isEmpty ? "(빈 문자열)" : userInfo.email)")
+    print("   name: \(userInfo.name.isEmpty ? "(빈 문자열)" : userInfo.name)")
+
+    // TextField 값으로 새로운 User 객체 생성
+    let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard !trimmedName.isEmpty else {
+      print("❌ [NameSettingViewModel] 이름이 비어있습니다")
+      showError = true
+      throw AuthenticationError.userNotFound
+    }
+
+    // email 처리: Firebase Auth에서 재확인 (없으면 빈 문자열 유지)
+    var email = userInfo.email
+    if email.isEmpty {
+      print("⚠️ [NameSettingViewModel] email이 빈 문자열입니다")
+
+      // Firebase Auth의 email 재확인
+      if let authEmail = authManager.user?.email, !authEmail.isEmpty {
+        email = authEmail
+        print("✅ [NameSettingViewModel] Firebase Auth에서 email 찾음: \(email)")
+      } else {
+        print("⚠️ [NameSettingViewModel] email 없이 저장됨 (Apple이 email 제공 안함)")
+      }
+    }
+
+    let newUser = User(
+      userId: userInfo.userId,
+      email: email,  // Firebase Auth email 또는 dummy email
+      name: trimmedName,  // ← TextField 값 사용!
+      loginType: LoginType(rawValue: userInfo.loginType) ?? .apple,
+      status: UserStatus(rawValue: userInfo.status) ?? .active,
+      fcmToken: userInfo.fcmToken,
+      termsAgreed: userInfo.termsAgreed,
+      privacyAgreed: userInfo.privacyAgreed
+    )
+
+    print("✅ [NameSettingViewModel] Firestore에 저장할 User 객체:")
+    print("   userId: \(newUser.userId)")
+    print("   email: \(newUser.email)")
+    print("   name: \(newUser.name)")
+
     do {
-      try await storeManager.createUser(userInfo)
+      try await storeManager.createUser(newUser)
+      print("✅ [NameSettingViewModel] Firestore 저장 성공")
+
+      // authManager.userInfo도 업데이트
+      authManager.userInfo = newUser
     } catch {
+      print("❌ [NameSettingViewModel] Firestore 저장 실패: \(error.localizedDescription)")
       showError = true
       throw FirestoreError.addFailed(underlying: error)
     }

--- a/DanceMachine/DanceMachine/Presentations/Login/Views/NameSettingView.swift
+++ b/DanceMachine/DanceMachine/Presentations/Login/Views/NameSettingView.swift
@@ -97,7 +97,8 @@ struct NameSettingView: View {
         ) {
           Task {
             dismissKeyboard()
-            try await viewModel.createNewuser()
+            // TextField 값 전달!
+            try await viewModel.createNewuser(name: name)
             viewModel.completeNameSetting()
           }
         }

--- a/DanceMachine/DanceMachine/Presentations/MyPage/ViewModels/AccountRecoveryViewModel.swift
+++ b/DanceMachine/DanceMachine/Presentations/MyPage/ViewModels/AccountRecoveryViewModel.swift
@@ -17,6 +17,8 @@ final class AccountRecoveryViewModel {
   var isLoading: Bool = false
   var showError: Bool = false
   var errorMessage: String = ""
+  var showLoadingToast: Bool = false
+  var loadingToastMessage: String = ""
 
   // MARK: - Step 2: Teamspace Selection
   var teamspaceOptions: [TeamspaceOption] = []
@@ -59,7 +61,12 @@ final class AccountRecoveryViewModel {
     }
 
     isLoading = true
-    defer { isLoading = false }
+    loadingToastMessage = String(localized: "계정 검색 중입니다. 잠시만 기다려주세요.")
+    showLoadingToast = true
+    defer {
+      isLoading = false
+      showLoadingToast = false
+    }
 
     do {
       print("🔍 [AccountRecovery] 계정 검색 시작")
@@ -140,7 +147,12 @@ final class AccountRecoveryViewModel {
     }
 
     isLoading = true
-    defer { isLoading = false }
+    loadingToastMessage = String(localized: "복구 중입니다. 잠시만 기다려주세요.")
+    showLoadingToast = true
+    defer {
+      isLoading = false
+      showLoadingToast = false
+    }
 
     do {
       print("🔐 [AccountRecovery] 계정 복구 시작")

--- a/DanceMachine/DanceMachine/Presentations/MyPage/ViewModels/AccountRecoveryViewModel.swift
+++ b/DanceMachine/DanceMachine/Presentations/MyPage/ViewModels/AccountRecoveryViewModel.swift
@@ -1,0 +1,206 @@
+//
+//  AccountRecoveryViewModel.swift
+//  DanceMachine
+//
+//  Created by 조재훈 on 1/13/26.
+//
+
+import Foundation
+import FirebaseAuth
+import FirebaseFunctions
+
+@Observable
+final class AccountRecoveryViewModel {
+
+  // MARK: - Step 1: Name Input
+  var userName: String = ""
+  var isLoading: Bool = false
+  var showError: Bool = false
+  var errorMessage: String = ""
+
+  // MARK: - Step 2: Teamspace Selection
+  var teamspaceOptions: [TeamspaceOption] = []
+  var selectedTeamspaceId: String? = nil
+
+  // MARK: - Step 3: Result
+  var recoverySuccess: Bool = false
+  var recoveryMessage: String = ""
+
+  // MARK: - Internal State
+  private var candidateUserId: String? = nil
+  private var correctTeamspaceIds: [String] = []
+  private let functions = Functions.functions(region: "asia-northeast3")
+
+  var currentStep: RecoveryStep = .nameInput
+
+  enum RecoveryStep {
+    case nameInput
+    case teamspaceSelection
+    case result
+  }
+
+  struct TeamspaceOption: Identifiable {
+    let id: String
+    let name: String
+  }
+
+  /// Step 1: 이름으로 계정 검색
+  func findAccount() async {
+    guard !userName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      errorMessage = "이름을 입력해주세요."
+      showError = true
+      return
+    }
+
+    guard let currentUid = FirebaseAuthManager.shared.user?.uid else {
+      errorMessage = "로그인이 필요합니다."
+      showError = true
+      return
+    }
+
+    isLoading = true
+    defer { isLoading = false }
+
+    do {
+      print("🔍 [AccountRecovery] 계정 검색 시작")
+      print("   입력된 이름: \(userName)")
+      print("   현재 UID: \(currentUid)")
+
+      let callable = functions.httpsCallable("findAccountForRecovery")
+      let data: [String: Any] = [
+        "userName": userName.trimmingCharacters(in: .whitespacesAndNewlines),
+        "currentUid": currentUid
+      ]
+
+      let result = try await callable.call(data)
+
+      guard let response = result.data as? [String: Any] else {
+        print("❌ [AccountRecovery] 응답 형식 오류")
+        errorMessage = "서버 오류가 발생했습니다."
+        showError = true
+        return
+      }
+
+      guard let found = response["found"] as? Bool, found else {
+        print("⚠️ [AccountRecovery] 계정을 찾을 수 없음")
+        errorMessage = response["message"] as? String ?? "해당 이름의 계정을 찾을 수 없습니다."
+        showError = true
+        return
+      }
+
+      // 후보 계정 정보 저장
+      guard let candidateId = response["candidateUserId"] as? String,
+            let teamspaces = response["teamspaceOptions"] as? [[String: String]],
+            let correctIds = response["correctTeamspaceIds"] as? [String] else {
+        print("❌ [AccountRecovery] 응답 데이터 파싱 실패")
+        errorMessage = "서버 응답 오류가 발생했습니다."
+        showError = true
+        return
+      }
+
+      self.candidateUserId = candidateId
+      self.correctTeamspaceIds = correctIds
+      self.teamspaceOptions = teamspaces.compactMap { dict in
+        guard let id = dict["id"], let name = dict["name"] else { return nil }
+        return TeamspaceOption(id: id, name: name)
+      }
+
+      print("✅ [AccountRecovery] 계정 검색 성공")
+      print("   후보 UID: \(candidateId)")
+      print("   팀스페이스 옵션 수: \(teamspaceOptions.count)")
+
+      // Step 2로 이동
+      currentStep = .teamspaceSelection
+
+    } catch {
+      print("❌ [AccountRecovery] 검색 실패: \(error.localizedDescription)")
+      errorMessage = "계정 검색 중 오류가 발생했습니다."
+      showError = true
+    }
+  }
+
+  /// Step 2: 팀스페이스 선택 후 계정 복구
+  func verifyAndRecover() async {
+    guard let selectedId = selectedTeamspaceId else {
+      errorMessage = "팀스페이스를 선택해주세요."
+      showError = true
+      return
+    }
+
+    guard let candidateId = candidateUserId else {
+      errorMessage = "내부 오류가 발생했습니다."
+      showError = true
+      return
+    }
+
+    guard let currentUid = FirebaseAuthManager.shared.user?.uid else {
+      errorMessage = "로그인이 필요합니다."
+      showError = true
+      return
+    }
+
+    isLoading = true
+    defer { isLoading = false }
+
+    do {
+      print("🔐 [AccountRecovery] 계정 복구 시작")
+      print("   선택된 팀스페이스 ID: \(selectedId)")
+
+      let callable = functions.httpsCallable("verifyAndRecoverAccount")
+      let data: [String: Any] = [
+        "candidateUserId": candidateId,
+        "selectedTeamspaceId": selectedId,
+        "currentUid": currentUid,
+        "correctTeamspaceIds": correctTeamspaceIds
+      ]
+
+      let result = try await callable.call(data)
+
+      guard let response = result.data as? [String: Any],
+            let success = response["success"] as? Bool,
+            let message = response["message"] as? String else {
+        print("❌ [AccountRecovery] 응답 형식 오류")
+        errorMessage = "서버 오류가 발생했습니다."
+        showError = true
+        return
+      }
+
+      if success {
+        print("✅ [AccountRecovery] 계정 복구 성공!")
+        recoverySuccess = true
+        recoveryMessage = message
+        currentStep = .result
+
+        // 사용자 정보 갱신
+        let refreshedUser: User = try await FirestoreManager.shared.get(currentUid, from: .users)
+        FirebaseAuthManager.shared.userInfo = refreshedUser
+
+        print("✅ [AccountRecovery] 사용자 정보 갱신 완료")
+
+      } else {
+        print("❌ [AccountRecovery] 계정 복구 실패")
+        errorMessage = message
+        showError = true
+      }
+
+    } catch {
+      print("❌ [AccountRecovery] 복구 실패: \(error.localizedDescription)")
+      errorMessage = "계정 복구 중 오류가 발생했습니다."
+      showError = true
+    }
+  }
+
+  /// 처음부터 다시 시작
+  func reset() {
+    userName = ""
+    selectedTeamspaceId = nil
+    teamspaceOptions = []
+    candidateUserId = nil
+    correctTeamspaceIds = []
+    recoverySuccess = false
+    recoveryMessage = ""
+    errorMessage = ""
+    showError = false
+    currentStep = .nameInput
+  }
+}

--- a/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountRecoveryView.swift
+++ b/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountRecoveryView.swift
@@ -1,0 +1,302 @@
+//
+//  AccountRecoveryView.swift
+//  DanceMachine
+//
+//  Created by 조재훈 on 1/13/26.
+//
+
+import SwiftUI
+
+struct AccountRecoveryView: View {
+  @Environment(\.dismiss) private var dismiss
+  @State private var viewModel = AccountRecoveryViewModel()
+
+  var body: some View {
+    ZStack {
+      Color.backgroundElevated.ignoresSafeArea()
+
+      VStack(spacing: 0) {
+        switch viewModel.currentStep {
+        case .nameInput:
+          nameInputStep
+        case .teamspaceSelection:
+          teamspaceSelectionStep
+        case .result:
+          resultStep
+        }
+      }
+    }
+    .toolbar {
+      ToolbarItem(placement: .navigationBarLeading) {
+        Button(action: {
+          if !viewModel.isLoading {
+            dismiss()
+          }
+        }) {
+          Image(systemName: "chevron.left")
+            .foregroundStyle(viewModel.isLoading ? Color.labelAssitive : Color.labelStrong)
+        }
+        .disabled(viewModel.isLoading)
+      }
+      ToolbarCenterTitle(text: "계정 복구")
+    }
+    .dismissKeyboardOnTap()
+    .interactiveDismissDisabled(viewModel.isLoading)
+    .onAppear {
+      // 이메일이 Unknown이거나 이름이 비어있거나 Unknown인 계정만 복구 가능
+      let currentEmail = FirebaseAuthManager.shared.userInfo?.email ?? "Unknown"
+      let currentName = FirebaseAuthManager.shared.userInfo?.name ?? "Unknown"
+
+      let isRecoverable = currentEmail == "Unknown" || currentName.isEmpty || currentName == "Unknown"
+
+      if !isRecoverable {
+        viewModel.errorMessage = "계정 복구 대상이 아닙니다. 고객지원에 문의해 주세요."
+        viewModel.showError = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+          dismiss()
+        }
+      }
+    }
+    .toast(
+      isPresented: $viewModel.showError,
+      duration: 2,
+      position: .bottom,
+      bottomPadding: 16,
+      content: {
+        ToastView(
+          text: viewModel.errorMessage,
+          icon: .warning
+        )
+      }
+    )
+  }
+
+  // MARK: - Step 1: Name Input
+  private var nameInputStep: some View {
+    VStack(spacing: 0) {
+      Text("복구할 계정의 사용자 이름을 입력해주세요")
+        .font(.title2SemiBold)
+        .foregroundStyle(Color.labelStrong)
+        .padding(.top, 24)
+
+      Spacer().frame(height: 16)
+
+      Text("이전에 사용하던 계정의 사용자 이름을 정확히 입력해주세요.")
+        .font(.headline1Medium)
+        .foregroundStyle(Color.labelNormal)
+        .multilineTextAlignment(.center)
+
+      Spacer().frame(height: 32)
+
+      TextField("이름", text: $viewModel.userName)
+        .font(.headline1Medium)
+        .foregroundStyle(Color.labelStrong)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color.backgroundNormal)
+        .cornerRadius(8)
+        .padding(.horizontal, 16)
+
+      Spacer()
+    }
+    .safeAreaInset(edge: .bottom) {
+        ActionButton(
+          title: viewModel.isLoading ? "계정 검색 중..." : "다음",
+          color: viewModel.userName.isEmpty ? Color.fillAssitive : Color.secondaryStrong,
+          height: 47,
+          isEnabled: !viewModel.userName.isEmpty && !viewModel.isLoading,
+          isLoading: viewModel.isLoading
+        ) {
+          Task {
+            await viewModel.findAccount()
+          }
+        }
+        .padding(.all, 16)
+    }
+  }
+
+  // MARK: - Step 2: Teamspace Selection
+  private var teamspaceSelectionStep: some View {
+    VStack(spacing: 0) {
+      Text("소속된 팀스페이스를 선택해주세요")
+        .font(.title2SemiBold)
+        .foregroundStyle(Color.labelStrong)
+        .padding(.top, 24)
+
+      Spacer().frame(height: 16)
+
+      Text("보안을 위해 본인이 속해있던 팀스페이스를 선택해주세요.")
+        .font(.headline1Medium)
+        .foregroundStyle(Color.labelNormal)
+        .multilineTextAlignment(.center)
+
+      Spacer().frame(height: 8)
+
+      Text("⚠️ 복구 작업은 1~2분 정도 소요될 수 있습니다.\n화면을 이탈하지 말고 기다려주세요.")
+        .font(.caption1Medium)
+        .foregroundStyle(Color.labelAssitive)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 16)
+
+      Spacer().frame(height: 24)
+
+      VStack(spacing: 12) {
+        ForEach(viewModel.teamspaceOptions) { option in
+          TeamspaceOptionButton(
+            title: option.name,
+            isSelected: viewModel.selectedTeamspaceId == option.id
+          ) {
+            viewModel.selectedTeamspaceId = option.id
+          }
+        }
+      }
+      .padding(.horizontal, 16)
+
+      Spacer()
+    }
+    .safeAreaInset(edge: .bottom) {
+        ActionButton(
+          title: viewModel.isLoading ? "계정 복구 중..." : "계정 복구",
+          color: viewModel.selectedTeamspaceId == nil ? Color.fillAssitive : Color.secondaryStrong,
+          height: 47,
+          isEnabled: viewModel.selectedTeamspaceId != nil && !viewModel.isLoading,
+          isLoading: viewModel.isLoading
+        ) {
+          Task {
+            await viewModel.verifyAndRecover()
+          }
+        }
+        .padding(.all, 16)
+    }
+  }
+
+  // MARK: - Step 3: Result
+  private var resultStep: some View {
+    VStack(spacing: 0) {
+      Spacer()
+      if viewModel.recoverySuccess {
+        Image(systemName: "checkmark.circle.fill")
+          .font(.system(size: 64))
+          .foregroundStyle(Color.green)
+
+        Spacer().frame(height: 24)
+
+        Text("계정 복구 성공!")
+          .font(.title2SemiBold)
+          .foregroundStyle(Color.labelStrong)
+
+        Spacer().frame(height: 16)
+
+        Text(viewModel.recoveryMessage)
+          .font(.headline1Medium)
+          .foregroundStyle(Color.labelNormal)
+          .multilineTextAlignment(.center)
+          .padding(.horizontal, 32)
+
+        Spacer().frame(height: 24)
+
+        VStack(spacing: 8) {
+          Text("복구되지 않은 데이터가 있다면")
+            .font(.caption1Medium)
+            .foregroundStyle(Color.labelAssitive)
+
+          Text("마이페이지 > 문의 및 고객 지원에서 문의해 주세요.")
+            .font(.caption1Medium)
+            .foregroundStyle(Color.labelAssitive)
+
+          Spacer().frame(height: 12)
+
+          Text("더 나은 서비스를 위해 노력하겠습니다.")
+            .font(.caption1Medium)
+            .foregroundStyle(Color.labelNormal)
+        }
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 32)
+      } else {
+        Image(systemName: "xmark.circle.fill")
+          .font(.system(size: 64))
+          .foregroundStyle(Color.red)
+
+        Spacer().frame(height: 24)
+
+        Text("계정 복구 실패")
+          .font(.title2SemiBold)
+          .foregroundStyle(Color.labelStrong)
+
+        Spacer().frame(height: 16)
+
+        Text(viewModel.recoveryMessage)
+          .font(.headline1Medium)
+          .foregroundStyle(Color.labelNormal)
+          .multilineTextAlignment(.center)
+          .padding(.horizontal, 32)
+      }
+
+      Spacer()
+    }
+    .safeAreaInset(edge: .bottom) {
+      VStack(spacing: 12) {
+        if viewModel.recoverySuccess {
+          ActionButton(
+            title: "확인",
+            color: Color.secondaryStrong,
+            height: 47
+          ) {
+            dismiss()
+          }
+        } else {
+          ActionButton(
+            title: "다시 시도",
+            color: Color.secondaryStrong,
+            height: 47
+          ) {
+            viewModel.reset()
+          }
+
+          ActionButton(
+            title: "취소",
+            color: Color.fillAssitive,
+            height: 47
+          ) {
+            dismiss()
+          }
+        }
+      }
+      .padding(.all, 16)
+    }
+  }
+}
+
+// MARK: - Teamspace Option Button
+fileprivate struct TeamspaceOptionButton: View {
+  let title: String
+  let isSelected: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack {
+        Text(title)
+          .font(.body1Medium)
+          .foregroundStyle(isSelected ? Color.white : Color.labelStrong)
+
+        Spacer()
+
+        if isSelected {
+          Image(systemName: "checkmark.circle.fill")
+            .foregroundStyle(Color.white)
+        }
+      }
+      .padding(.horizontal, 16)
+      .padding(.vertical, 16)
+      .background(isSelected ? Color.secondaryStrong : Color.backgroundNormal)
+      .cornerRadius(8)
+    }
+  }
+}
+
+#Preview {
+  NavigationStack {
+    AccountRecoveryView()
+  }
+}

--- a/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountRecoveryView.swift
+++ b/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountRecoveryView.swift
@@ -61,11 +61,23 @@ struct AccountRecoveryView: View {
       isPresented: $viewModel.showError,
       duration: 2,
       position: .bottom,
-      bottomPadding: 16,
+      bottomPadding: 79,
       content: {
         ToastView(
           text: viewModel.errorMessage,
           icon: .warning
+        )
+      }
+    )
+    .toast(
+      isPresented: $viewModel.showLoadingToast,
+      duration: 30,
+      position: .bottom,
+      bottomPadding: 79,
+      content: {
+        ToastView(
+          text: viewModel.loadingToastMessage,
+          icon: .check
         )
       }
     )

--- a/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountRecoveryView.swift
+++ b/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountRecoveryView.swift
@@ -219,7 +219,7 @@ struct AccountRecoveryView: View {
           Spacer().frame(height: 12)
 
           Text("더 나은 서비스를 위해 노력하겠습니다.")
-            .font(.caption1Medium)
+            .font(.headline1Medium)
             .foregroundStyle(Color.labelNormal)
         }
         .multilineTextAlignment(.center)

--- a/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountRecoveryView.swift
+++ b/DanceMachine/DanceMachine/Presentations/MyPage/Views/AccountRecoveryView.swift
@@ -38,7 +38,7 @@ struct AccountRecoveryView: View {
         }
         .disabled(viewModel.isLoading)
       }
-      ToolbarCenterTitle(text: "계정 복구")
+      ToolbarCenterTitle(text: String(localized: "계정 복구"))
     }
     .dismissKeyboardOnTap()
     .interactiveDismissDisabled(viewModel.isLoading)
@@ -50,7 +50,7 @@ struct AccountRecoveryView: View {
       let isRecoverable = currentEmail == "Unknown" || currentName.isEmpty || currentName == "Unknown"
 
       if !isRecoverable {
-        viewModel.errorMessage = "계정 복구 대상이 아닙니다. 고객지원에 문의해 주세요."
+        viewModel.errorMessage = String(localized: "계정 복구 대상이 아닙니다. 고객지원에 문의해 주세요.")
         viewModel.showError = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
           dismiss()
@@ -88,7 +88,7 @@ struct AccountRecoveryView: View {
 
       Spacer().frame(height: 32)
 
-      TextField("이름", text: $viewModel.userName)
+      TextField(String(localized: "이름"), text: $viewModel.userName)
         .font(.headline1Medium)
         .foregroundStyle(Color.labelStrong)
         .padding(.horizontal, 16)
@@ -101,7 +101,7 @@ struct AccountRecoveryView: View {
     }
     .safeAreaInset(edge: .bottom) {
         ActionButton(
-          title: viewModel.isLoading ? "계정 검색 중..." : "다음",
+          title: viewModel.isLoading ? String(localized: "계정 검색 중...") : String(localized: "다음"),
           color: viewModel.userName.isEmpty ? Color.fillAssitive : Color.secondaryStrong,
           height: 47,
           isEnabled: !viewModel.userName.isEmpty && !viewModel.isLoading,
@@ -156,7 +156,7 @@ struct AccountRecoveryView: View {
     }
     .safeAreaInset(edge: .bottom) {
         ActionButton(
-          title: viewModel.isLoading ? "계정 복구 중..." : "계정 복구",
+          title: viewModel.isLoading ? String(localized: "계정 복구 중...") : String(localized: "계정 복구"),
           color: viewModel.selectedTeamspaceId == nil ? Color.fillAssitive : Color.secondaryStrong,
           height: 47,
           isEnabled: viewModel.selectedTeamspaceId != nil && !viewModel.isLoading,
@@ -238,7 +238,7 @@ struct AccountRecoveryView: View {
       VStack(spacing: 12) {
         if viewModel.recoverySuccess {
           ActionButton(
-            title: "확인",
+            title: String(localized: "확인"),
             color: Color.secondaryStrong,
             height: 47
           ) {
@@ -246,7 +246,7 @@ struct AccountRecoveryView: View {
           }
         } else {
           ActionButton(
-            title: "다시 시도",
+            title: String(localized: "다시 시도"),
             color: Color.secondaryStrong,
             height: 47
           ) {
@@ -254,7 +254,7 @@ struct AccountRecoveryView: View {
           }
 
           ActionButton(
-            title: "취소",
+            title: String(localized: "취소"),
             color: Color.fillAssitive,
             height: 47
           ) {

--- a/DanceMachine/DanceMachine/Presentations/MyPage/Views/MyPageView.swift
+++ b/DanceMachine/DanceMachine/Presentations/MyPage/Views/MyPageView.swift
@@ -102,7 +102,7 @@ struct MyPageView: View {
       bottomPadding: 16,
       content: {
         ToastView(
-          text: "계정 복구 대상이 아닙니다. 고객지원에 문의해 주세요.",
+          text: String(localized: "계정 복구 대상이 아닙니다. 고객지원에 문의해 주세요."),
           icon: .warning
         )
       }

--- a/DanceMachine/DanceMachine/Presentations/MyPage/Views/MyPageView.swift
+++ b/DanceMachine/DanceMachine/Presentations/MyPage/Views/MyPageView.swift
@@ -16,7 +16,8 @@ struct MyPageView: View {
   
   @State private var showContactView: Bool = false
   @State private var showContactSucessToast: Bool = false
-  
+  @State private var showRecoveryAccessDeniedToast: Bool = false
+
   var body: some View {
     ZStack {
       Color.backgroundNormal.ignoresSafeArea()
@@ -59,6 +60,14 @@ struct MyPageView: View {
           MyPageNavigationRow(title: String(localized: "계정 설정"), isDividerPresented: true) {
             router.push(to: .mypage(.accountSetting))
           }
+          MyPageNavigationRow(title: String(localized: "계정 복구"), isDividerPresented: true) {
+            // 이메일이 Unknown이거나 이름이 비어있거나 Unknown인 계정만 복구 가능
+            if viewModel.myId == "Unknown" || viewModel.myName.isEmpty || viewModel.myName == "Unknown" {
+              router.push(to: .mypage(.accountRecovery))
+            } else {
+              showRecoveryAccessDeniedToast = true
+            }
+          }
           MyPageInfoRow(title: String(localized: "앱 버전"), value: viewModel.appVersion, isDividerPresented: true)
           MyPageNavigationRow(title: String(localized: "문의 및 고객 지원"), isDividerPresented: true) {
             self.showContactView = true
@@ -85,6 +94,18 @@ struct MyPageView: View {
       icon: .check,
       for: .toast(.contactSuccess),
       bottomPadding: 16
+    )
+    .toast(
+      isPresented: $showRecoveryAccessDeniedToast,
+      duration: 2,
+      position: .bottom,
+      bottomPadding: 16,
+      content: {
+        ToastView(
+          text: "계정 복구 대상이 아닙니다. 고객지원에 문의해 주세요.",
+          icon: .warning
+        )
+      }
     )
   }
 }

--- a/DanceMachine/DanceMachine/Presentations/RootView.swift
+++ b/DanceMachine/DanceMachine/Presentations/RootView.swift
@@ -18,37 +18,21 @@ struct RootView: View {
   @State private var showAccountRecoveryAlert = false
 
   var body: some View {
-    NavigationStack(path: $router.destination) {
-      TabView(selection: $tabcase) {
-        ForEach(TabCase.allCases) { tab in
-          Tab(value: tab) {
-            tabView(tab: tab)
-              .tag(tab)
-          } label: { tabLabel(tab) }
-            .badge(
-              tab == .inbox ? notificationManager.unreadNotificationCount : 0
-            )
+    mainContent
+      .preferredColorScheme(.dark)
+      .onChange(of: tabcase) { oldValue, newValue in
+        if oldValue != newValue {
+          router.destination.removeAll()
         }
       }
-      .navigationDestination(for: MainRoute.self) { destination in
-        MainNavigationRoutingView(destination: destination)
-          .environmentObject(router)
-      }
-    }
-    .preferredColorScheme(.dark)
-    .onChange(of: tabcase) { oldValue, newValue in
-      if oldValue != newValue {
-        router.destination.removeAll()
-      }
-    }
-    .onAppear {
+      .onAppear {
       // 기존 유저의 country 필드 업데이트 (1회만)
       if !hasUpdatedCountry {
         updateUserCountryIfNeeded()
       }
 
-      // 이메일이 Unknown이거나 이름이 비어있거나 Unknown인 사용자에게 한 번만 알림 표시
-      if !hasShownAccountRecoveryAlert {
+      // 1.1.7 버전 이상에서만 계정 복구 알림 표시 (1회만)
+      if !hasShownAccountRecoveryAlert && isVersion117OrHigher() {
         let currentEmail = FirebaseAuthManager.shared.userInfo?.email ?? "Unknown"
         let currentName = FirebaseAuthManager.shared.userInfo?.name ?? "Unknown"
 
@@ -68,7 +52,27 @@ struct RootView: View {
       Text("앱 업데이트로 계정 정보가 초기화 되신 유저분들은\n마이페이지 > 계정 복구 탭에서 복구할 수 있습니다.")
     }
   }
-  
+
+  private var mainContent: some View {
+    NavigationStack(path: $router.destination) {
+      TabView(selection: $tabcase) {
+        ForEach(TabCase.allCases) { tab in
+          Tab(value: tab) {
+            tabView(tab: tab)
+              .tag(tab)
+          } label: { tabLabel(tab) }
+            .badge(
+              tab == .inbox ? notificationManager.unreadNotificationCount : 0
+            )
+        }
+      }
+      .navigationDestination(for: MainRoute.self) { destination in
+        MainNavigationRoutingView(destination: destination)
+          .environmentObject(router)
+      }
+    }
+  }
+
   private func tabLabel(_ tab: TabCase) -> some View {
     VStack(spacing: 8, content: {
       Image(systemName: tab.icon)
@@ -98,6 +102,27 @@ struct RootView: View {
       )
       .environmentObject(router)
     }
+  }
+
+  /// 현재 앱 버전이 1.1.7 이상인지 확인
+  private func isVersion117OrHigher() -> Bool {
+    guard let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+      return false
+    }
+
+    let components = appVersion.split(separator: ".").compactMap { Int($0) }
+    guard components.count >= 3 else { return false }
+
+    let major = components[0]
+    let minor = components[1]
+    let patch = components[2]
+
+    // 1.1.7 이상인지 확인
+    if major > 1 { return true }
+    if major == 1 && minor > 1 { return true }
+    if major == 1 && minor == 1 && patch >= 7 { return true }
+
+    return false
   }
 
   /// 기존 유저의 country 필드 업데이트 (Firestore에 country 필드가 없는 경우)

--- a/DanceMachine/DanceMachine/Presentations/RootView.swift
+++ b/DanceMachine/DanceMachine/Presentations/RootView.swift
@@ -12,7 +12,10 @@ struct RootView: View {
   @EnvironmentObject private var router: MainRouter
   @State var tabcase: TabCase = .home
   @StateObject private var notificationManager = NotificationManager.shared
-  
+
+  @AppStorage("hasShownAccountRecoveryAlert") private var hasShownAccountRecoveryAlert = false
+  @State private var showAccountRecoveryAlert = false
+
   var body: some View {
     NavigationStack(path: $router.destination) {
       TabView(selection: $tabcase) {
@@ -36,6 +39,27 @@ struct RootView: View {
       if oldValue != newValue {
         router.destination.removeAll()
       }
+    }
+    .onAppear {
+      // 이메일이 Unknown이거나 이름이 비어있거나 Unknown인 사용자에게 한 번만 알림 표시
+      if !hasShownAccountRecoveryAlert {
+        let currentEmail = FirebaseAuthManager.shared.userInfo?.email ?? "Unknown"
+        let currentName = FirebaseAuthManager.shared.userInfo?.name ?? "Unknown"
+
+        let needsRecovery = currentEmail == "Unknown" || currentName.isEmpty || currentName == "Unknown"
+
+        if needsRecovery {
+          DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            showAccountRecoveryAlert = true
+            hasShownAccountRecoveryAlert = true
+          }
+        }
+      }
+    }
+    .alert("계정 복구 안내", isPresented: $showAccountRecoveryAlert) {
+      Button("확인", role: .cancel) { }
+    } message: {
+      Text("앱 업데이트로 계정 정보가 초기화 되신 유저분들은\n마이페이지 > 계정 복구 탭에서 복구할 수 있습니다.")
     }
   }
   

--- a/DanceMachine/DanceMachine/Presentations/RootView.swift
+++ b/DanceMachine/DanceMachine/Presentations/RootView.swift
@@ -14,6 +14,7 @@ struct RootView: View {
   @StateObject private var notificationManager = NotificationManager.shared
 
   @AppStorage("hasShownAccountRecoveryAlert") private var hasShownAccountRecoveryAlert = false
+  @AppStorage("hasUpdatedCountry") private var hasUpdatedCountry = false
   @State private var showAccountRecoveryAlert = false
 
   var body: some View {
@@ -41,6 +42,11 @@ struct RootView: View {
       }
     }
     .onAppear {
+      // 기존 유저의 country 필드 업데이트 (1회만)
+      if !hasUpdatedCountry {
+        updateUserCountryIfNeeded()
+      }
+
       // 이메일이 Unknown이거나 이름이 비어있거나 Unknown인 사용자에게 한 번만 알림 표시
       if !hasShownAccountRecoveryAlert {
         let currentEmail = FirebaseAuthManager.shared.userInfo?.email ?? "Unknown"
@@ -91,6 +97,63 @@ struct RootView: View {
         destination: .mypage(.profile)
       )
       .environmentObject(router)
+    }
+  }
+
+  /// 기존 유저의 country 필드 업데이트 (Firestore에 country 필드가 없는 경우)
+  private func updateUserCountryIfNeeded() {
+    guard let userInfo = FirebaseAuthManager.shared.userInfo else {
+      print("[RootView] userInfo 없음 - country 업데이트 스킵")
+      return
+    }
+
+    Task {
+      do {
+        // Firestore에서 현재 유저 데이터 확인
+        let firestoreUser: User? = try? await FirestoreManager.shared.get(userInfo.userId, from: .users)
+
+        // country 필드가 비어있거나 없으면 업데이트
+        if firestoreUser == nil || firestoreUser?.country.isEmpty == true {
+          print("[RootView] country 필드 없음 - 'kr'로 업데이트")
+
+          // Firestore 업데이트
+          try await FirestoreManager.shared.updateFields(
+            collection: .users,
+            documentId: userInfo.userId,
+            asDictionary: [
+              User.CodingKeys.country.rawValue: "kr"
+            ]
+          )
+
+          // 로컬 userInfo 업데이트
+          let updatedUser = User(
+            userId: userInfo.userId,
+            email: userInfo.email,
+            name: userInfo.name,
+            loginType: LoginType(rawValue: userInfo.loginType) ?? .apple,
+            status: UserStatus(rawValue: userInfo.status) ?? .active,
+            fcmToken: userInfo.fcmToken,
+            termsAgreed: userInfo.termsAgreed,
+            privacyAgreed: userInfo.privacyAgreed,
+            country: "kr",
+            updatedAt: userInfo.updatedAt
+          )
+
+          FirebaseAuthManager.shared.userInfo = updatedUser
+
+          print("[RootView] country 업데이트 완료: kr")
+        } else {
+          print("[RootView] country 필드 이미 존재: \(firestoreUser?.country ?? "unknown")")
+        }
+
+        // 업데이트 완료 플래그 설정 (1회만 실행)
+        hasUpdatedCountry = true
+
+      } catch {
+        print("[RootView] country 업데이트 실패: \(error.localizedDescription)")
+        // 실패해도 플래그 설정 (무한 재시도 방지)
+        hasUpdatedCountry = true
+      }
     }
   }
 }

--- a/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
+++ b/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
@@ -599,6 +599,22 @@
         }
       }
     },
+    "⚠️ 복구 작업은 1~2분 정도 소요될 수 있습니다.\n화면을 이탈하지 말고 기다려주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⚠️ Recovery may take 1-2 minutes.\nPlease wait without leaving this screen."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⚠️ 復旧作業には1~2分程度かかる場合があります。\n画面を離れずにお待ちください。"
+          }
+        }
+      }
+    },
     "10/10" : {
       "localizations" : {
         "en" : {
@@ -979,6 +995,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "갤러리 접근 권한 요청"
+          }
+        }
+      }
+    },
+    "계정 복구" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account Recovery"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント復旧"
+          }
+        }
+      }
+    },
+    "계정 복구 성공!" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account Recovery Successful!"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント復旧成功！"
+          }
+        }
+      }
+    },
+    "계정 복구 실패" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account Recovery Failed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント復旧失敗"
+          }
+        }
+      }
+    },
+    "계정 복구 안내" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account Recovery Guide"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント復旧案内"
           }
         }
       }
@@ -1691,6 +1771,22 @@
         }
       }
     },
+    "더 나은 서비스를 위해 노력하겠습니다." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We will strive to provide better service."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "より良いサービスのために努力いたします。"
+          }
+        }
+      }
+    },
     "더 짧거나 낮은 화질의 영상을\n선택해 주세요." : {
       "localizations" : {
         "en" : {
@@ -2263,6 +2359,22 @@
         }
       }
     },
+    "마이페이지 > 문의 및 고객 지원에서 문의해 주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please contact us at My Page > Contact & Support."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マイページ > お問い合わせ・カスタマーサポートからお問い合わせください。"
+          }
+        }
+      }
+    },
     "마이피드백" : {
       "localizations" : {
         "en" : {
@@ -2483,6 +2595,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "변경하기"
+          }
+        }
+      }
+    },
+    "보안을 위해 본인이 속해있던 팀스페이스를 선택해주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "For security purposes, please select the teamspace you belonged to."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "セキュリティのため、ご自身が所属していたチームスペースを選択してください。"
+          }
+        }
+      }
+    },
+    "복구되지 않은 데이터가 있다면" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If there is any unrecovered data"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復旧されていないデータがある場合"
+          }
+        }
+      }
+    },
+    "복구할 계정의 이름을 입력해주세요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter the name of the account to recover"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復旧するアカウントの名前を入力してください"
           }
         }
       }
@@ -2851,6 +3011,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "선택한 팀원들을 내보내시겠어요?"
+          }
+        }
+      }
+    },
+    "소속된 팀스페이스를 선택해주세요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please select the teamspace you belong to"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所属しているチームスペースを選択してください"
           }
         }
       }
@@ -3299,6 +3475,22 @@
         }
       }
     },
+    "앱 업데이트로 계정 정보가 초기화되었습니다.\n마이페이지 > 계정 복구 탭에서 복구할 수 있습니다." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your account information was reset due to an app update.\nYou can recover it from My Page > Account Recovery tab."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリのアップデートによりアカウント情報が初期化されました。\nマイページ > アカウント復旧タブから復旧できます。"
+          }
+        }
+      }
+    },
     "업데이트가 필요합니다" : {
       "localizations" : {
         "en" : {
@@ -3541,6 +3733,22 @@
         }
       }
     },
+    "이름" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名前"
+          }
+        }
+      }
+    },
     "이름 수정" : {
       "localizations" : {
         "en" : {
@@ -3641,6 +3849,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이메일을 입력해주세요"
+          }
+        }
+      }
+    },
+    "이전에 사용하던 계정 이름을 정확히 입력해주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please enter the exact name of your previous account."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以前使用していたアカウント名を正確に入力してください。"
           }
         }
       }

--- a/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
+++ b/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
@@ -5604,7 +5604,6 @@
       }
     },
     "프리뷰 용" : {
-      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
+++ b/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
@@ -999,6 +999,28 @@
         }
       }
     },
+    "계정 검색 중..." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Searching for account..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント検索中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정 검색 중..."
+          }
+        }
+      }
+    },
     "계정 복구" : {
       "localizations" : {
         "en" : {
@@ -1011,6 +1033,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アカウント復旧"
+          }
+        }
+      }
+    },
+    "계정 복구 대상이 아닙니다. 고객지원에 문의해 주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You are not eligible for account recovery. Please contact customer support."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント復旧の対象ではありません。カスタマーサポートにお問い合わせください。"
           }
         }
       }
@@ -1059,6 +1097,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アカウント復旧案内"
+          }
+        }
+      }
+    },
+    "계정 복구 중..." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recovering account..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント復旧中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정 복구 중..."
           }
         }
       }
@@ -1617,6 +1677,28 @@
         }
       }
     },
+    "다시 시도" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Again"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再試行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다시 시도"
+          }
+        }
+      }
+    },
     "다시 초대받아 참여할 수 있습니다." : {
       "localizations" : {
         "en" : {
@@ -1635,6 +1717,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "다시 초대받아 참여할 수 있습니다."
+          }
+        }
+      }
+    },
+    "다음" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次へ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음"
           }
         }
       }
@@ -2631,18 +2735,18 @@
         }
       }
     },
-    "복구할 계정의 이름을 입력해주세요" : {
+    "복구할 계정의 사용자 이름을 입력해주세요" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enter the name of the account to recover"
+            "value" : "Enter the username of the account to recover"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "復旧するアカウントの名前を入力してください"
+            "value" : "復旧するアカウントのユーザー名を入力してください"
           }
         }
       }
@@ -3475,18 +3579,18 @@
         }
       }
     },
-    "앱 업데이트로 계정 정보가 초기화되었습니다.\n마이페이지 > 계정 복구 탭에서 복구할 수 있습니다." : {
+    "앱 업데이트로 계정 정보가 초기화 되신 유저분들은\n마이페이지 > 계정 복구 탭에서 복구할 수 있습니다." : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your account information was reset due to an app update.\nYou can recover it from My Page > Account Recovery tab."
+            "value" : "If your account information was reset due to the app update,\nyou can recover it from My Page > Account Recovery tab."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アプリのアップデートによりアカウント情報が初期化されました。\nマイページ > アカウント復旧タブから復旧できます。"
+            "value" : "アプリのアップデートでアカウント情報が初期化されたユーザー様は\nマイページ > アカウント復旧タブから復旧できます。"
           }
         }
       }
@@ -3853,18 +3957,18 @@
         }
       }
     },
-    "이전에 사용하던 계정 이름을 정확히 입력해주세요." : {
+    "이전에 사용하던 계정의 사용자 이름을 정확히 입력해주세요." : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Please enter the exact name of your previous account."
+            "value" : "Please enter the exact username of your previous account."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "以前使用していたアカウント名を正確に入力してください。"
+            "value" : "以前使用していたアカウントのユーザー名を正確に入力してください。"
           }
         }
       }

--- a/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
+++ b/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
@@ -5778,6 +5778,50 @@
           }
         }
       }
+    },
+    "계정 검색 중입니다. 잠시만 기다려주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Searching for account. Please wait."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント検索中です。しばらくお待ちください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정 검색 중입니다. 잠시만 기다려주세요."
+          }
+        }
+      }
+    },
+    "복구 중입니다. 잠시만 기다려주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recovering account. Please wait."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復旧中です。しばらくお待ちください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복구 중입니다. 잠시만 기다려주세요."
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
+++ b/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
@@ -5604,6 +5604,7 @@
       }
     },
     "프리뷰 용" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
+++ b/DanceMachine/DanceMachine/Resource/Localizable.xcstrings
@@ -1021,6 +1021,28 @@
         }
       }
     },
+    "계정 검색 중입니다. 잠시만 기다려주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Searching for account. Please wait."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アカウント検索中です。しばらくお待ちください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계정 검색 중입니다. 잠시만 기다려주세요."
+          }
+        }
+      }
+    },
     "계정 복구" : {
       "localizations" : {
         "en" : {
@@ -2715,6 +2737,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "セキュリティのため、ご自身が所属していたチームスペースを選択してください。"
+          }
+        }
+      }
+    },
+    "복구 중입니다. 잠시만 기다려주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recovering account. Please wait."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復旧中です。しばらくお待ちください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복구 중입니다. 잠시만 기다려주세요."
           }
         }
       }
@@ -5560,6 +5604,7 @@
       }
     },
     "프리뷰 용" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -5775,50 +5820,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "회원탈퇴"
-          }
-        }
-      }
-    },
-    "계정 검색 중입니다. 잠시만 기다려주세요." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Searching for account. Please wait."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アカウント検索中です。しばらくお待ちください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "계정 검색 중입니다. 잠시만 기다려주세요."
-          }
-        }
-      }
-    },
-    "복구 중입니다. 잠시만 기다려주세요." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recovering account. Please wait."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "復旧中です。しばらくお待ちください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "복구 중입니다. 잠시만 기다려주세요."
           }
         }
       }

--- a/DanceMachine/DanceMachine/Service/FirebaseAuthManager.swift
+++ b/DanceMachine/DanceMachine/Service/FirebaseAuthManager.swift
@@ -35,30 +35,62 @@ final class FirebaseAuthManager: ObservableObject {
   var isSigningIn: Bool = false
   
   private init() {
-    // 앱을 다시 다운로드했는데, 자동으로 로그인되지 않게 하기 위한 로그아웃
+    print("🔧 [FirebaseAuthManager] 초기화 시작")
+    print("   hasLaunchedBefore: \(hasLaunchedBefore)")
+    print("   didCompleteAuthFlow: \(didCompleteAuthFlow)")
+    print("   currentUser: \(firebaseAuth.currentUser?.uid ?? "nil")")
+
+    // ⚠️ 중요: hasLaunchedBefore 로직 개선
+    // 앱 재설치 시에만 로그아웃하되, 더 안전하게 처리
     if !hasLaunchedBefore {
-      Task { try firebaseAuth.signOut() }
+      print("⚠️ [FirebaseAuthManager] 첫 실행 감지 - 초기화 진행")
+
+      // 현재 로그인되어 있고, 플로우 완료 안됐으면 비정상 상태
+      if firebaseAuth.currentUser != nil && !didCompleteAuthFlow {
+        print("🔄 [FirebaseAuthManager] 비정상 인증 상태 감지 - 로그아웃 실행")
+        do {
+          try firebaseAuth.signOut()
+          print("✅ [FirebaseAuthManager] 강제 로그아웃 완료")
+        } catch {
+          print("❌ [FirebaseAuthManager] 로그아웃 실패: \(error.localizedDescription)")
+        }
+      } else {
+        print("ℹ️ [FirebaseAuthManager] 정상 상태 - 로그아웃 불필요")
+      }
+
       hasLaunchedBefore = true
+      print("✅ [FirebaseAuthManager] hasLaunchedBefore = true 설정 완료")
     }
-    
+
     // 현재 사용자 인증 상태 확인
     if let user = firebaseAuth.currentUser {
+      print("👤 [FirebaseAuthManager] currentUser 존재: \(user.uid)")
+
       if !didCompleteAuthFlow {
-        // 로그인 플로우가 완료하지 않았는데 currentUser가 있는 상태 → 비정상 로그인 -> 로그아웃
-        Task { try? firebaseAuth.signOut() }
+        // 로그인 플로우가 완료하지 않았는데 currentUser가 있는 상태
+        print("⚠️ [FirebaseAuthManager] didCompleteAuthFlow=false 이지만 currentUser 존재")
+        print("   → 비정상 로그인 상태, 로그아웃 실행")
+        do {
+          try firebaseAuth.signOut()
+          print("✅ [FirebaseAuthManager] 비정상 상태 로그아웃 완료")
+        } catch {
+          print("❌ [FirebaseAuthManager] 로그아웃 실패: \(error.localizedDescription)")
+        }
         self.authenticationState = .unauthenticated
       } else {
         // 정상 로그인 완료된 상태
+        print("✅ [FirebaseAuthManager] 정상 로그인 상태")
         self.user = user
         self.authenticationState = .authenticated
       }
     } else {
+      print("🚫 [FirebaseAuthManager] currentUser 없음 - 로그아웃 상태")
       self.authenticationState = .unauthenticated
     }
-    
+
     registerAuthStateHandler()
     verifySignInWithAppleAuthenticationState()
-    print("FirebaseAuthManager initialized")
+    print("✅ [FirebaseAuthManager] 초기화 완료")
   }
   
   /// 사용자 인증 상태를 확인하는 리스너를 등록하는 메서드
@@ -92,16 +124,21 @@ final class FirebaseAuthManager: ObservableObject {
   ///     - uid: 사용자 id (Firebase Authentication 에서 반환 - users 콜렉션에서 id로 사용중)
   @MainActor
   func fetchUserInfo(for uid: String) async throws {
-    print("Fetch user information for \(uid)")
+    print("🔍 [FirebaseAuthManager] fetchUserInfo 시작 - uid: \(uid)")
     do {
       if let user: User = try await FirestoreManager.shared.get(uid, from: .users) {
+        print("✅ [FirebaseAuthManager] Firestore에서 유저 조회 성공")
+        print("   name: \(user.name)")
+        print("   email: \(user.email)")
         self.userInfo = user
       } else {
+        print("⚠️ [FirebaseAuthManager] Firestore에서 유저 없음 (nil)")
         self.userInfo = nil
       }
     } catch {
+      print("❌ [FirebaseAuthManager] fetchUserInfo 실패: \(error.localizedDescription)")
       self.authenticationState = .unauthenticated
-      print("Failed to fetch user information: \(FirestoreError.fetchFailed(underlying: error).localizedDescription)")
+      throw error
     }
   }
   
@@ -303,12 +340,49 @@ extension FirebaseAuthManager {
   
   @discardableResult
   func signInWithApple(tokens: SignInWithAppleResult) async throws -> AuthDataResult {
-    let credential = OAuthProvider.appleCredential(withIDToken: tokens.token, rawNonce: tokens.nonce, fullName: tokens.fullName)
-    return try await signIn(credential: credential)
+    print("🔐 [FirebaseAuthManager] signInWithApple 시작")
+    print("   Apple User ID: \(tokens.appleUserId)")
+
+    let credential = OAuthProvider.appleCredential(
+      withIDToken: tokens.token,
+      rawNonce: tokens.nonce,
+      fullName: tokens.fullName
+    )
+
+    let authDataResult = try await signIn(credential: credential)
+
+    print("🔑 [FirebaseAuthManager] Firebase UID: \(authDataResult.user.uid)")
+    print("   Provider ID: \(authDataResult.user.providerID)")
+
+    // ⚠️ 중요: UID 변경 감지
+    if let existingUID = UserDefaults.standard.string(forKey: "lastKnownUID_\(tokens.appleUserId)") {
+      if existingUID != authDataResult.user.uid {
+        print("🚨🚨🚨 [FirebaseAuthManager] UID 변경 감지!")
+        print("   기존 UID: \(existingUID)")
+        print("   새 UID: \(authDataResult.user.uid)")
+        print("   Apple User ID: \(tokens.appleUserId)")
+      } else {
+        print("✅ [FirebaseAuthManager] UID 일치")
+      }
+    } else {
+      print("📝 [FirebaseAuthManager] 첫 로그인 - UID 저장")
+    }
+
+    // UID 저장 (다음번 로그인 시 비교용)
+    UserDefaults.standard.set(authDataResult.user.uid, forKey: "lastKnownUID_\(tokens.appleUserId)")
+
+    return authDataResult
   }
-  
+
   func signIn(credential: AuthCredential) async throws -> AuthDataResult {
     let authDataResult = try await firebaseAuth.signIn(with: credential)
+
+    // additionalUserInfo 확인 (디버깅용)
+    if let additionalUserInfo = authDataResult.additionalUserInfo {
+      print("ℹ️ [FirebaseAuthManager] isNewUser: \(additionalUserInfo.isNewUser)")
+      print("   profile: \(additionalUserInfo.profile ?? [:])")
+    }
+
     return authDataResult
   }
   

--- a/DanceMachine/DanceMachine/Service/FirestoreManager.swift
+++ b/DanceMachine/DanceMachine/Service/FirestoreManager.swift
@@ -87,7 +87,41 @@ final class FirestoreManager {
   // TODO: 코드 논의
   @discardableResult
   func createUser<T: EntityRepresentable>(_ data: T) async throws -> T {
-    try await save(data, strategy: .userStrategy)
+    print("🔐 [FirestoreManager] createUser 시작")
+
+    // Cast to User to validate fields
+    guard let user = data as? User else {
+      print("⚠️ [FirestoreManager] 데이터를 User 타입으로 변환 실패")
+      return try await save(data, strategy: .userStrategy)
+    }
+
+    print("📋 [FirestoreManager] 저장할 User 데이터:")
+    print("   userId: \(user.userId)")
+    print("   email: \(user.email.isEmpty ? "(빈 문자열)" : user.email)")
+    print("   name: \(user.name.isEmpty ? "(빈 문자열)" : user.name)")
+
+    // email 경고만 출력 (저장은 허용)
+    if user.email.isEmpty || user.email.contains("@diract.app") {
+      print("⚠️ [FirestoreManager] email이 비어있거나 dummy email입니다")
+      print("   → 저장은 진행하지만, 나중에 실제 email로 업데이트 필요")
+    }
+
+    // Critical validation: reject blank name
+    guard !user.name.isEmpty else {
+      print("🚨🚨🚨 [FirestoreManager] 치명적 오류!")
+      print("   name이 빈 문자열입니다.")
+      print("   Firestore 저장을 중단합니다.")
+      throw FirestoreError.addFailed(
+        underlying: NSError(
+          domain: "FirestoreManager",
+          code: -1,
+          userInfo: [NSLocalizedDescriptionKey: "User name cannot be empty"]
+        )
+      )
+    }
+
+    print("✅ [FirestoreManager] 검증 통과 - Firestore 저장 진행")
+    return try await save(data, strategy: .userStrategy)
   }
   
   // TODO: 코드 논의

--- a/DanceMachine/DanceMachine/Service/SignInWithAppleHelper.swift
+++ b/DanceMachine/DanceMachine/Service/SignInWithAppleHelper.swift
@@ -71,7 +71,56 @@ final class SignInAppleHelper: NSObject {
     let hashedData = SHA256.hash(data: inputData)
     return hashedData.map { String(format: "%02x", $0) }.joined()
   }
-  
+
+  /// JWT에서 transfer_sub 클레임 추출
+  /// - Parameter idToken: Apple Identity Token (JWT)
+  /// - Returns: transfer_sub 값 (존재하지 않으면 nil)
+  private func extractTransferSub(from idToken: String) -> String? {
+    // JWT는 header.payload.signature 형식
+    let segments = idToken.components(separatedBy: ".")
+    guard segments.count == 3 else {
+      print("⚠️ [SignInAppleHelper] Invalid JWT format")
+      return nil
+    }
+
+    let payloadSegment = segments[1]
+
+    // Base64URL 디코딩
+    var base64 = payloadSegment
+      .replacingOccurrences(of: "-", with: "+")
+      .replacingOccurrences(of: "_", with: "/")
+
+    // Padding 추가
+    let remainder = base64.count % 4
+    if remainder > 0 {
+      base64.append(String(repeating: "=", count: 4 - remainder))
+    }
+
+    guard let payloadData = Data(base64Encoded: base64) else {
+      print("⚠️ [SignInAppleHelper] Failed to decode payload")
+      return nil
+    }
+
+    // JSON 파싱
+    do {
+      let json = try JSONSerialization.jsonObject(with: payloadData, options: [])
+      guard let payload = json as? [String: Any] else {
+        print("⚠️ [SignInAppleHelper] Invalid payload format")
+        return nil
+      }
+
+      // transfer_sub 추출
+      if let transferSub = payload["transfer_sub"] as? String {
+        return transferSub
+      }
+
+      return nil
+    } catch {
+      print("⚠️ [SignInAppleHelper] JSON parsing error: \(error)")
+      return nil
+    }
+  }
+
   private enum SignInWithAppleError: LocalizedError {
     case noViewController
     case invalidCredential
@@ -102,25 +151,79 @@ final class SignInAppleHelper: NSObject {
 extension SignInAppleHelper: ASAuthorizationControllerDelegate {
   
   func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-    guard
-      let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
-      let appleIDToken = appleIDCredential.identityToken,
-      let idTokenString = String(data: appleIDToken, encoding: .utf8),
-      let nonce = currentNonce else {
+    print("🍎 [SignInAppleHelper] Apple Sign-In 성공 콜백")
+
+    guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+      print("❌ [SignInAppleHelper] AppleIDCredential 변환 실패")
+      completionHandler?(.failure(SignInWithAppleError.invalidCredential))
+      return
+    }
+
+    guard let appleIDToken = appleIDCredential.identityToken else {
+      print("❌ [SignInAppleHelper] identityToken 없음")
       completionHandler?(.failure(SignInWithAppleError.badResponse))
       return
     }
-    
+
+    guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+      print("❌ [SignInAppleHelper] identityToken UTF8 변환 실패")
+      completionHandler?(.failure(SignInWithAppleError.badResponse))
+      return
+    }
+
+    guard let nonce = currentNonce else {
+      print("❌ [SignInAppleHelper] currentNonce 없음")
+      completionHandler?(.failure(SignInWithAppleError.unableToFindNonce))
+      return
+    }
+
+    // Apple User Identifier (디버깅용 - 이 값이 바뀌는지 추적)
+    let appleUserId = appleIDCredential.user
+    print("📱 [SignInAppleHelper] Apple User ID: \(appleUserId)")
+
     let fullName = appleIDCredential.fullName
     let email = appleIDCredential.email
-    let tokens = SignInWithAppleResult(token: idTokenString, nonce: nonce,
-                                       appleIDCredential: appleIDCredential, fullName: fullName, email: email)
+
+    // 중요: email과 fullName은 최초 로그인 시에만 제공됨
+    if let email = email {
+      print("📧 [SignInAppleHelper] Email 제공됨: \(email)")
+    } else {
+      print("⚠️ [SignInAppleHelper] Email 제공 안됨 (재로그인 또는 이메일 숨김)")
+    }
+
+    if let fullName = fullName {
+      print("👤 [SignInAppleHelper] FullName 제공됨: \(fullName)")
+    } else {
+      print("⚠️ [SignInAppleHelper] FullName 제공 안됨 (재로그인)")
+    }
+
+    // transfer_sub 추출 (App Transfer 시에만 존재)
+    let transferSub = extractTransferSub(from: idTokenString)
+
+    if let transferSub = transferSub {
+      print("🔄 [SignInAppleHelper] Transfer Sub 감지: \(transferSub)")
+      print("   → App Transfer 감지! Migration 필요")
+    } else {
+      print("ℹ️ [SignInAppleHelper] Transfer Sub 없음 (정상 로그인)")
+    }
+
+    let tokens = SignInWithAppleResult(
+      token: idTokenString,
+      nonce: nonce,
+      appleIDCredential: appleIDCredential,
+      fullName: fullName,
+      email: email,
+      appleUserId: appleUserId,
+      transferSub: transferSub
+    )
+
+    print("✅ [SignInAppleHelper] Apple Sign-In 완료")
     completionHandler?(.success(tokens))
   }
   
   func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-    print("Sign in with Apple errored: \(error)")
-    completionHandler?(.failure(URLError(.cannotFindHost)))
+    print("❌ [SignInAppleHelper] Apple Sign-In 실패: \(error.localizedDescription)")
+    completionHandler?(.failure(error))
   }
 }
 
@@ -132,6 +235,8 @@ struct SignInWithAppleResult {
   let appleIDCredential: ASAuthorizationAppleIDCredential
   let fullName: PersonNameComponents?
   let email: String?
+  let appleUserId: String  // Apple User Identifier (디버깅 및 추적용)
+  let transferSub: String?  // App Transfer 시 이전 identifier (Migration용)
 }
 
 ///  애플 로그인 버튼

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,10 +6,12 @@
     "": {
       "name": "functions",
       "dependencies": {
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/nodemailer": "^7.0.4",
         "es-hangul": "^2.3.8",
         "firebase-admin": "^12.6.0",
         "firebase-functions": "^6.0.1",
+        "jsonwebtoken": "^9.0.3",
         "nodemailer": "^7.0.12",
         "uuid": "^13.0.0"
       },
@@ -8033,12 +8035,12 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -8054,33 +8056,11 @@
         "npm": ">=6"
       }
     },
-    "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -8105,13 +8085,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,10 +16,12 @@
   },
   "main": "lib/index.js",
   "dependencies": {
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/nodemailer": "^7.0.4",
     "es-hangul": "^2.3.8",
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^6.0.1",
+    "jsonwebtoken": "^9.0.3",
     "nodemailer": "^7.0.12",
     "uuid": "^13.0.0"
   },

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -759,6 +759,7 @@ export const verifyAndRecoverAccount = onCall(async (request) => {
     await db.collection("users").doc(currentUid).set({
       ...oldUserData,
       user_id: currentUid,  // ← 새 UID로 변경
+      country: oldUserData.country || "kr",  // ← country 필드 없으면 기본값 추가
       updated_at: admin.firestore.FieldValue.serverTimestamp(),
     });
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -37,16 +37,21 @@
 
 import * as admin from "firebase-admin";
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
+import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { setGlobalOptions } from "firebase-functions";
 import * as logger from "firebase-functions/logger";
 import { defineString } from "firebase-functions/params";
 import { josa } from "es-hangul";
 import { v4 as uuidv4 } from "uuid";
 import * as nodemailer from "nodemailer";
+import * as jwt from "jsonwebtoken";
 
 // 환경 변수 정의
 const gmailUser = defineString("GMAIL_USER");
 const gmailPassword = defineString("GMAIL_PASSWORD");
+
+// Apple Sign-In Migration 환경 변수 (Secret Manager에서 자동 주입됨)
+// defineString 대신 process.env로 접근 (함수 내에서 secrets 선언 시 자동 주입)
 
 admin.initializeApp();
 setGlobalOptions({ region: "asia-northeast3", maxInstances: 10 });
@@ -423,3 +428,678 @@ export const sendInquiryEmail = onDocumentCreated("inquiries/{inquiryId}", async
     logger.error("[Inquiry] - Error sending email", { userId, error });
   }
 });
+
+/**
+ * =============================================================================
+ * Apple Sign-In Transfer Identifier Migration
+ * =============================================================================
+ */
+
+/**
+ * Apple용 JWT 생성
+ * Apple Migration API 인증에 필요한 client secret 토큰 생성
+ */
+function generateAppleClientSecret(): string {
+  const now = Math.floor(Date.now() / 1000);
+
+  const payload = {
+    iss: process.env.APPLE_TEAM_ID,
+    iat: now,
+    exp: now + 86400 * 180, // 180일 (최대값)
+    aud: "https://appleid.apple.com",
+    sub: "com.dirAct", // Bundle ID
+  };
+
+  const privateKey = (process.env.APPLE_PRIVATE_KEY || "").replace(/\\n/g, "\n"); // 개행 처리
+
+  const token = jwt.sign(payload, privateKey, {
+    algorithm: "ES256",
+    keyid: process.env.APPLE_KEY_ID,
+  });
+
+  return token;
+}
+
+/**
+ * Apple Migration API 호출
+ * transfer_sub를 사용하여 기존 사용자 식별자 조회
+ *
+ * @param transferSub - Apple Sign-In에서 제공하는 transfer_sub 값
+ * @returns 기존 사용자 식별자 (sub)
+ */
+async function getTransferredAppleUserId(transferSub: string): Promise<string | null> {
+  try {
+    const clientSecret = generateAppleClientSecret();
+
+    const response = await fetch("https://appleid.apple.com/auth/usermigrationinfo", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: "com.dirAct", // Bundle ID
+        client_secret: clientSecret,
+        transfer_sub: transferSub,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.error("[Apple Migration] API error", {
+        status: response.status,
+        statusText: response.statusText,
+        error: errorText
+      });
+      return null;
+    }
+
+    const data = await response.json();
+    logger.info("[Apple Migration] API success", { data });
+
+    // Apple API는 { sub: "기존 식별자" } 형태로 반환
+    return data.sub || null;
+  } catch (error) {
+    logger.error("[Apple Migration] API call failed", { error, transferSub });
+    return null;
+  }
+}
+
+/**
+ * 사용자 마이그레이션 HTTPS Callable Function
+ * iOS 앱에서 호출하여 transfer_sub로 기존 계정 찾고 병합
+ *
+ * @param data.transferSub - Apple Sign-In의 transfer_sub
+ * @param data.currentUid - 현재 Firebase UID
+ * @param data.email - 사용자 이메일 (옵션)
+ * @param data.name - 사용자 이름 (옵션)
+ */
+export const migrateAppleUser = onCall(
+  {
+    secrets: ["APPLE_TEAM_ID", "APPLE_KEY_ID", "APPLE_PRIVATE_KEY"],
+  },
+  async (request) => {
+    const { transferSub, currentUid, email, name } = request.data;
+
+    logger.info("[Migration] 시작", { transferSub, currentUid, email, name });
+
+    // 입력 검증
+    if (!transferSub || typeof transferSub !== "string") {
+      throw new HttpsError("invalid-argument", "transferSub is required");
+    }
+    if (!currentUid || typeof currentUid !== "string") {
+      throw new HttpsError("invalid-argument", "currentUid is required");
+    }
+
+    try {
+      // 1. Apple Migration API로 기존 식별자 조회
+      const originalSub = await getTransferredAppleUserId(transferSub);
+
+      if (!originalSub) {
+        logger.warn("[Migration] 기존 식별자를 찾을 수 없음", { transferSub });
+        return {
+          success: false,
+          message: "No original user found",
+          migratedFrom: null,
+        };
+      }
+
+      logger.info("[Migration] 기존 식별자 찾음", { originalSub });
+
+      // 2. Firebase Auth에서 기존 사용자 찾기 (UID가 originalSub인 사용자)
+      try {
+        await admin.auth().getUser(originalSub);
+        logger.info("[Migration] Firebase Auth에서 기존 유저 찾음", { uid: originalSub });
+      } catch (error) {
+        logger.warn("[Migration] Firebase Auth에 기존 유저 없음", { originalSub, error });
+        // Firebase Auth에 없으면 Firestore만 확인
+      }
+
+      // 3. Firestore에서 기존 사용자 문서 찾기
+      const originalUserDoc = await db.collection("users").doc(originalSub).get();
+
+      if (!originalUserDoc.exists) {
+        logger.warn("[Migration] Firestore에 기존 유저 문서 없음", { originalSub });
+        return {
+          success: false,
+          message: "Original user document not found in Firestore",
+          migratedFrom: originalSub,
+        };
+      }
+
+      const originalUserData = originalUserDoc.data();
+      logger.info("[Migration] 기존 유저 데이터 찾음", {
+        originalSub,
+        originalEmail: originalUserData?.email,
+        originalName: originalUserData?.name,
+      });
+
+      // 4. 현재 UID로 생성된 문서가 있는지 확인 (신규 유저로 잘못 생성된 문서)
+      const currentUserDoc = await db.collection("users").doc(currentUid).get();
+
+      if (currentUserDoc.exists) {
+        // 현재 UID 문서 삭제 (중복 방지)
+        logger.info("[Migration] 현재 UID 문서 삭제", { currentUid });
+        await db.collection("users").doc(currentUid).delete();
+      }
+
+      // 5. 기존 문서에 새 UID 정보 업데이트 (필요시)
+      // 주의: Firebase Auth의 UID는 변경할 수 없으므로,
+      // 앱에서는 originalSub을 UID로 사용하도록 재로그인 필요
+
+      // email/name 업데이트 (Private Email 대응)
+      const updateData: any = {
+        updated_at: admin.firestore.FieldValue.serverTimestamp(),
+      };
+
+      if (email && email !== originalUserData?.email) {
+        updateData.email = email;
+        logger.info("[Migration] 이메일 업데이트", { oldEmail: originalUserData?.email, newEmail: email });
+      }
+
+      if (name && name !== originalUserData?.name && originalUserData?.name !== "Unknown") {
+        // 기존 이름이 "Unknown"이 아니면 유지
+        logger.info("[Migration] 기존 이름 유지", { originalName: originalUserData?.name });
+      } else if (name) {
+        updateData.name = name;
+        logger.info("[Migration] 이름 업데이트", { oldName: originalUserData?.name, newName: name });
+      }
+
+      await db.collection("users").doc(originalSub).update(updateData);
+      logger.info("[Migration] 사용자 데이터 업데이트 완료", { originalSub, updateData });
+
+      return {
+        success: true,
+        message: "Migration successful",
+        migratedFrom: originalSub,
+        originalEmail: originalUserData?.email,
+        originalName: originalUserData?.name,
+      };
+
+    } catch (error) {
+      logger.error("[Migration] 실패", { error, transferSub, currentUid });
+      throw new HttpsError("internal", "Migration failed", error);
+    }
+  }
+);
+
+/**
+ * =============================================================================
+ * Account Recovery for 1.1.5 Users
+ * =============================================================================
+ */
+
+/**
+ * Step 1: 이름으로 후보 계정 찾고 팀스페이스 검증 문제 생성
+ */
+export const findAccountForRecovery = onCall(async (request) => {
+  const { userName, currentUid } = request.data;
+
+  logger.info("[AccountRecovery] 계정 검색 시작", { userName, currentUid });
+
+  // 1. 이름으로 후보 찾기
+  const candidates = await db.collection("users")
+    .where("name", "==", userName)
+    .get();
+
+  if (candidates.empty) {
+    logger.warn("[AccountRecovery] 후보 없음", { userName });
+    return {
+      found: false,
+      message: "해당 이름의 계정을 찾을 수 없습니다",
+    };
+  }
+
+  // 동명이인이 있을 수 있으므로 첫 번째만 사용
+  const candidate = candidates.docs[0];
+  const candidateUserId = candidate.id;
+
+  logger.info("[AccountRecovery] 후보 발견", { candidateUserId });
+
+  // 2. 후보의 팀스페이스 조회
+  const realTeamspaces: Array<{id: string, name: string}> = [];
+
+  // 사용자가 속한 모든 팀스페이스 찾기
+  const allTeamspaces = await db.collection("teamspace").get();
+  logger.info("[AccountRecovery] 전체 팀스페이스 조회", {
+    totalTeamspaces: allTeamspaces.size
+  });
+
+  for (const ts of allTeamspaces.docs) {
+    const memberDoc = await ts.ref.collection("members").doc(candidateUserId).get();
+    logger.info("[AccountRecovery] members 체크", {
+      teamspaceId: ts.id,
+      teamspaceName: ts.data().teamspace_name,
+      memberExists: memberDoc.exists,
+      candidateUserId
+    });
+
+    if (memberDoc.exists) {
+      realTeamspaces.push({
+        id: ts.id,
+        name: ts.data().teamspace_name,
+      });
+    }
+  }
+
+  if (realTeamspaces.length === 0) {
+    logger.warn("[AccountRecovery] 팀스페이스 없음", { candidateUserId });
+    return {
+      found: false,
+      message: "계정을 찾았으나 팀스페이스가 없습니다. 고객센터로 문의해주세요.",
+    };
+  }
+
+  // 3. 가짜 팀스페이스 추가 (다른 사람 것)
+  const fakeTeamspaces: Array<{id: string, name: string}> = [];
+  const otherTeamspaces = allTeamspaces.docs
+    .filter((ts) => !realTeamspaces.some((rt) => rt.id === ts.id))
+    .slice(0, 2);  // 가짜 2개만
+
+  for (const ts of otherTeamspaces) {
+    fakeTeamspaces.push({
+      id: ts.id,
+      name: ts.data().teamspace_name,
+    });
+  }
+
+  // 4. 섞어서 반환 (3개)
+  const allOptions = [...realTeamspaces, ...fakeTeamspaces]
+    .sort(() => Math.random() - 0.5)  // 랜덤 섞기
+    .slice(0, 3);
+
+  logger.info("[AccountRecovery] 검증 문제 생성", {
+    candidateUserId,
+    realCount: realTeamspaces.length,
+    options: allOptions.length,
+  });
+
+  return {
+    found: true,
+    candidateUserId: candidateUserId,
+    teamspaceOptions: allOptions,
+    correctTeamspaceIds: realTeamspaces.map((t) => t.id),  // 클라이언트에는 안 보냄
+  };
+});
+
+/**
+ * Step 2: 팀스페이스 선택 검증 및 계정 복구 실행
+ */
+export const verifyAndRecoverAccount = onCall(async (request) => {
+  const { candidateUserId, selectedTeamspaceId, currentUid, correctTeamspaceIds } = request.data;
+
+  logger.info("[AccountRecovery] 검증 시작", {
+    candidateUserId,
+    selectedTeamspaceId,
+    currentUid,
+  });
+
+  // 1. 정답 확인
+  const isCorrect = correctTeamspaceIds.includes(selectedTeamspaceId);
+
+  if (!isCorrect) {
+    logger.warn("[AccountRecovery] 잘못된 선택", { selectedTeamspaceId, correctTeamspaceIds });
+    return {
+      success: false,
+      message: "선택이 올바르지 않습니다. 다시 시도해주세요.",
+    };
+  }
+
+  logger.info("[AccountRecovery] 검증 성공, 복구 시작");
+
+  try {
+    // 2. 기존 계정 데이터 가져오기
+    const oldUserDoc = await db.collection("users").doc(candidateUserId).get();
+    if (!oldUserDoc.exists) {
+      throw new Error("Original user not found");
+    }
+
+    const oldUserData = oldUserDoc.data()!;
+
+    // 3. currentUid에 기존 데이터 덮어쓰기 (userId만 변경)
+    await db.collection("users").doc(currentUid).set({
+      ...oldUserData,
+      user_id: currentUid,  // ← 새 UID로 변경
+      updated_at: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    logger.info("[AccountRecovery] users 문서 복구 완료");
+
+    // 3-1. 서브컬렉션 복사 (user_teamspace, user_notification)
+    await copyUserSubcollections(candidateUserId, currentUid);
+
+    // 4. 모든 참조 업데이트
+    await updateAllReferences(candidateUserId, currentUid);
+
+    // 5. 기존 계정을 Soft Delete (나중에 수동 확인/삭제 가능)
+    // 이메일과 이름에 _migrated를 붙여 충돌 방지
+    await db.collection("users").doc(candidateUserId).update({
+      status: "migrated",
+      email: `${oldUserData.email}_migrated`,
+      name: `${oldUserData.name}_migrated`,
+      migrated_to: currentUid,
+      migrated_at: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    logger.info("[AccountRecovery] 계정 복구 완료 (기존 계정은 migrated 상태로 유지)", {
+      oldUserId: candidateUserId,
+      newUserId: currentUid,
+    });
+
+    // 6. 관리자에게 이메일 알림 발송
+    try {
+      const recoveredUser = await db.collection("users").doc(currentUid).get();
+      const userData = recoveredUser.data();
+
+      const transporter = nodemailer.createTransport({
+        service: "gmail",
+        auth: {
+          user: gmailUser.value(),
+          pass: gmailPassword.value(),
+        },
+      });
+
+      const mailOptions = {
+        from: gmailUser.value(),
+        to: gmailUser.value(),
+        subject: "[DirAct 계정 복구] 계정 복구 완료 알림",
+        html: `
+          <h2>DirAct 계정 복구 완료</h2>
+          <p><strong>사용자 이름:</strong> ${userData?.name || "Unknown"}</p>
+          <p><strong>이메일:</strong> ${userData?.email || "N/A"}</p>
+          <p><strong>기존 UID:</strong> ${candidateUserId}</p>
+          <p><strong>새 UID:</strong> ${currentUid}</p>
+          <p><strong>복구 시간:</strong> ${new Date().toLocaleString("ko-KR")}</p>
+          <hr>
+          <p>사용자가 계정 복구를 성공적으로 완료했습니다.</p>
+        `,
+      };
+
+      await transporter.sendMail(mailOptions);
+      logger.info("[AccountRecovery] 이메일 발송 성공", { currentUid });
+    } catch (emailError) {
+      logger.error("[AccountRecovery] 이메일 발송 실패", { emailError });
+      // 이메일 실패는 복구 성공에 영향을 주지 않음
+    }
+
+    return {
+      success: true,
+      message: "계정이 성공적으로 복구되었습니다.",
+    };
+  } catch (error) {
+    logger.error("[AccountRecovery] 복구 실패", { error });
+    throw new HttpsError("internal", "Account recovery failed", error);
+  }
+});
+
+/**
+ * Helper: 모든 컬렉션의 userId 참조 업데이트
+ */
+async function updateAllReferences(oldUserId: string, newUserId: string) {
+  const batch = db.batch();
+  let batchCount = 0;
+
+  const commitBatch = async () => {
+    if (batchCount > 0) {
+      await batch.commit();
+      batchCount = 0;
+    }
+  };
+
+  logger.info("[AccountRecovery] 참조 업데이트 시작", { oldUserId, newUserId });
+
+  // 1. teamspace - ownerId
+  const teamspaces = await db.collection("teamspace")
+    .where("owner_id", "==", oldUserId)
+    .get();
+  for (const ts of teamspaces.docs) {
+    batch.update(ts.ref, { owner_id: newUserId });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  // 2. teamspace/{id}/members - userId (서브컬렉션)
+  const allTeamspaces = await db.collection("teamspace").get();
+  for (const ts of allTeamspaces.docs) {
+    const memberDoc = await ts.ref.collection("members").doc(oldUserId).get();
+    if (memberDoc.exists) {
+      // 기존 멤버 데이터 가져오기
+      const memberData = memberDoc.data() || {};
+
+      // 기존 멤버 삭제
+      await ts.ref.collection("members").doc(oldUserId).delete();
+
+      // 새 UID로 재생성 (모든 필드 복사하고 user_id만 업데이트)
+      await ts.ref.collection("members").doc(newUserId).set({
+        ...memberData,
+        user_id: newUserId,
+      });
+    }
+  }
+
+  // 3. project - creatorId
+  const projects = await db.collection("project")
+    .where("creator_id", "==", oldUserId)
+    .get();
+  for (const proj of projects.docs) {
+    batch.update(proj.ref, { creator_id: newUserId });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  // 4. tracks - creatorId
+  const tracks = await db.collection("tracks")
+    .where("creator_id", "==", oldUserId)
+    .get();
+  for (const track of tracks.docs) {
+    batch.update(track.ref, { creator_id: newUserId });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  // 5. video - uploaderId
+  const videos = await db.collection("video")
+    .where("uploader_id", "==", oldUserId)
+    .get();
+  for (const vid of videos.docs) {
+    batch.update(vid.ref, { uploader_id: newUserId });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  // 6. feedback - authorId, taggedUserIds
+  const feedbacks = await db.collection("feedback")
+    .where("author_id", "==", oldUserId)
+    .get();
+  for (const fb of feedbacks.docs) {
+    batch.update(fb.ref, { author_id: newUserId });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  const taggedFeedbacks = await db.collection("feedback")
+    .where("tagged_user_ids", "array-contains", oldUserId)
+    .get();
+  for (const fb of taggedFeedbacks.docs) {
+    const taggedIds = fb.data().tagged_user_ids || [];
+    const updatedIds = taggedIds.map((id: string) => id === oldUserId ? newUserId : id);
+    batch.update(fb.ref, { tagged_user_ids: updatedIds });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  // 7. feedback/{id}/reply - authorId, taggedUserIds (서브컬렉션)
+  const allFeedbacks = await db.collection("feedback").get();
+  for (const fb of allFeedbacks.docs) {
+    const replies = await fb.ref.collection("reply")
+      .where("author_id", "==", oldUserId)
+      .get();
+    for (const reply of replies.docs) {
+      batch.update(reply.ref, { author_id: newUserId });
+      batchCount++;
+      if (batchCount >= 500) await commitBatch();
+    }
+
+    const taggedReplies = await fb.ref.collection("reply")
+      .where("tagged_user_ids", "array-contains", oldUserId)
+      .get();
+    for (const reply of taggedReplies.docs) {
+      const taggedIds = reply.data().tagged_user_ids || [];
+      const updatedIds = taggedIds.map((id: string) => id === oldUserId ? newUserId : id);
+      batch.update(reply.ref, { tagged_user_ids: updatedIds });
+      batchCount++;
+      if (batchCount >= 500) await commitBatch();
+    }
+  }
+
+  // 8. notification - senderId, receiverIds
+  const senderNotifs = await db.collection("notification")
+    .where("sender_id", "==", oldUserId)
+    .get();
+  for (const notif of senderNotifs.docs) {
+    batch.update(notif.ref, { sender_id: newUserId });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  const receiverNotifs = await db.collection("notification")
+    .where("receiver_ids", "array-contains", oldUserId)
+    .get();
+  for (const notif of receiverNotifs.docs) {
+    const receiverIds = notif.data().receiver_ids || [];
+    const updatedIds = receiverIds.map((id: string) => id === oldUserId ? newUserId : id);
+    batch.update(notif.ref, { receiver_ids: updatedIds });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  // 9. report - reporterId, reportedId
+  const reporterReports = await db.collection("report")
+    .where("reporter_id", "==", oldUserId)
+    .get();
+  for (const report of reporterReports.docs) {
+    batch.update(report.ref, { reporter_id: newUserId });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  const reportedReports = await db.collection("report")
+    .where("reported_id", "==", oldUserId)
+    .get();
+  for (const report of reportedReports.docs) {
+    batch.update(report.ref, { reported_id: newUserId });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  // 10. invites - inviterId
+  const invites = await db.collection("invites")
+    .where("inviter_id", "==", oldUserId)
+    .get();
+  for (const invite of invites.docs) {
+    batch.update(invite.ref, { inviter_id: newUserId });
+    batchCount++;
+    if (batchCount >= 500) await commitBatch();
+  }
+
+  // 11. users/{oldUserId}/blocks → users/{newUserId}/blocks (서브컬렉션 이동)
+  const blocks = await db.collection("users").doc(oldUserId).collection("blocks").get();
+  for (const block of blocks.docs) {
+    await db.collection("users").doc(newUserId).collection("blocks").doc(block.id).set(block.data());
+    await block.ref.delete();
+  }
+
+  // 12. 다른 사람이 oldUserId를 차단한 경우
+  const allUsers = await db.collection("users").get();
+  for (const user of allUsers.docs) {
+    const blockDoc = await user.ref.collection("blocks").doc(oldUserId).get();
+    if (blockDoc.exists) {
+      await user.ref.collection("blocks").doc(oldUserId).delete();
+      await user.ref.collection("blocks").doc(newUserId).set({
+        blocked_user_id: newUserId,
+      });
+    }
+  }
+
+  await commitBatch();
+  logger.info("[AccountRecovery] 모든 참조 업데이트 완료");
+}
+
+/**
+ * Helper: users 서브컬렉션 복사 (user_teamspace, user_notification)
+ */
+async function copyUserSubcollections(oldUserId: string, newUserId: string) {
+  logger.info("[AccountRecovery] 서브컬렉션 복사 시작", { oldUserId, newUserId });
+
+  // 1. user_teamspace 서브컬렉션 복사
+  const userTeamspaces = await db.collection("users")
+    .doc(oldUserId)
+    .collection("user_teamspace")
+    .get();
+
+  for (const doc of userTeamspaces.docs) {
+    await db.collection("users")
+      .doc(newUserId)
+      .collection("user_teamspace")
+      .doc(doc.id)
+      .set(doc.data());
+  }
+
+  logger.info("[AccountRecovery] user_teamspace 복사 완료", {
+    count: userTeamspaces.size,
+  });
+
+  // 2. user_notification 서브컬렉션 복사
+  const userNotifications = await db.collection("users")
+    .doc(oldUserId)
+    .collection("user_notification")
+    .get();
+
+  for (const doc of userNotifications.docs) {
+    await db.collection("users")
+      .doc(newUserId)
+      .collection("user_notification")
+      .doc(doc.id)
+      .set(doc.data());
+  }
+
+  logger.info("[AccountRecovery] user_notification 복사 완료", {
+    count: userNotifications.size,
+  });
+}
+
+/**
+ * Helper: users 문서 및 서브컬렉션 삭제
+ *
+ * NOTE: Soft delete 정책으로 변경되어 현재 사용하지 않음.
+ * 나중에 수동으로 migrated 계정을 삭제할 때 사용 가능.
+ *
+ * @internal - 수동 관리용으로만 export
+ */
+export async function deleteUserWithSubcollections(userId: string) {
+  logger.info("[AccountRecovery] 사용자 삭제 시작 (서브컬렉션 포함)", { userId });
+
+  // 1. user_teamspace 서브컬렉션 삭제
+  const userTeamspaces = await db.collection("users")
+    .doc(userId)
+    .collection("user_teamspace")
+    .get();
+
+  for (const doc of userTeamspaces.docs) {
+    await doc.ref.delete();
+  }
+
+  // 2. user_notification 서브컬렉션 삭제
+  const userNotifications = await db.collection("users")
+    .doc(userId)
+    .collection("user_notification")
+    .get();
+
+  for (const doc of userNotifications.docs) {
+    await doc.ref.delete();
+  }
+
+  // 3. users 문서 삭제
+  await db.collection("users").doc(userId).delete();
+
+  logger.info("[AccountRecovery] 사용자 삭제 완료", { userId });
+}


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 작업 이슈 번호를 입력해주세요
- Closes #168 


## 🛠️ 작업내용
- 앱 이전 후 이메일과 이름이 빈 상태로 새 유저 컬렉션이 생성되며, 기존 계정을 못 쓰는 버그가 생겨 계정 복구 기능을 추가하였습니다.
- 마이 페이지 > 계정 복구 탭에서 전에 썼던 계정의 이름과 속해있었던 팀스페이스를 선택하는 식으로 검증하여 새로생긴 user컬렉션에 기존 user컬렉션의 정보를 덮어 씌웁니다.
- 기존 user컬렉션의 정보로 생성되었던 모든 컨텐츠들을 새 user컬렉션의 id로 업데이트 합니다.
- 계정 복구에 성공하면 디랙트 이메일로 메일을 발송됩니다.


## 📋 시연 영상





